### PR TITLE
S0014 :Change "source" to type "string"

### DIFF
--- a/schemas/tlc/1.1/sxl.yaml
+++ b/schemas/tlc/1.1/sxl.yaml
@@ -423,7 +423,7 @@ objects:
             min: 1
             max: 255
           source:
-            type: string_list
+            type: string
             description: Source of the status change
             values:
               operator_panel: Operator panel 


### PR DESCRIPTION
It it not needed for "source" in S0014 to be a **string_list**. It can be a **string** since only one time plan can be active at once in a TLC