### PR TITLE
S0015 'source' doesn't need to be string_list

### DIFF
--- a/schemas/tlc/1.1/sxl.yaml
+++ b/schemas/tlc/1.1/sxl.yaml
@@ -454,7 +454,7 @@ objects:
             min: 1
             max: 255
           source:
-            type: string_list
+            type: string
             description: Source of the status change
             values:
               operator_panel: Operator panel


### PR DESCRIPTION
Only one "traffic situation" can be active at once.

This PR changes **string_list** to **string** for the source attribute