### PR TITLE
Mark "extendedinputstatus" and "extendedoutputstatus" as deprecated

### DIFF
--- a/schemas/tlc/1.1/sxl.yaml
+++ b/schemas/tlc/1.1/sxl.yaml
@@ -177,6 +177,7 @@ objects:
               - : Input is undefined/does not exist
           extendedinputstatus:
             type: string
+            deprecated: true
             description: |-
               Extended input status as text field
               Each character represent the state of the extended input status in consecutive order.
@@ -198,6 +199,7 @@ objects:
               - : Output is undefined/does not exist
           extendedoutputstatus:
             type: string
+            deprecated: true
             description: |-
               Extended output status as text field
               Each character represent the state of the extended output status in consecutive order.


### PR DESCRIPTION
A while ago we agreed on marking "extendedinputstatus" in S0003 and "extendedoutputstatus" in S0004 as deprecated in 1.1, Se https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/issues/74

They are noted as deprecated in the online doc and pdf, but the yaml file doesn't include this yet.

This PR suggest we adds `deprecated: true` for "extendedinputstatus" in S0003 and "extendedoutputstatus" in S0004