### PR TITLE
M0001: Command does not use comma separated list

### DIFF
--- a/schemas/tlc/1.1/sxl.yaml
+++ b/schemas/tlc/1.1/sxl.yaml
@@ -1089,14 +1089,14 @@ objects:
           Requires security code 2.
         arguments:
           status:
-            type: string_list
+            type: string
             description: Set operating mode
             values:
               NormalControl: Normal Control
               YellowFlash: Enables yellow flash
               Dark: Enables dark mode
           securityCode:
-            type: string_list
+            type: string
             description: Security code 2
           timeout:
             type: integer
@@ -1106,10 +1106,8 @@ objects:
             min: 0
             max: 1440
           intersection:
-            type: integer_list
-            description: |-
-              Comma separated list of intersections which the status relates to, e.g. “1,2”.
-              Use “0” for all intersections of the TLC.
+            type: integer
+            description: Intersection number
             min: 0
             max: 255
         command: setValue


### PR DESCRIPTION
This command does not use comma separated list. The intersection the command refers to is defined by the attribute 'intersection'

Also fix the description of the 'intersection'. See the M0001 in the [online doc](https://rsmp-nordic.org/rsmp_specifications/rsmp_sxl_traffic_lights/1.1/sxl_traffic_light_controller.html#m0001) for reference.