### PR TITLE
Use 'values' for description texts where possible

### DIFF
--- a/schemas/tlc/1.1/sxl.yaml
+++ b/schemas/tlc/1.1/sxl.yaml
@@ -699,14 +699,10 @@ objects:
             max: 255
           status:
             type: string_list
-            description: |-
+            values:
               local: Local coordination
               centralized: Coordination with synchronized clock
-              off: Coordination not active
-            values:
-              local:
-              centralized:
-              'off':
+              'off': Coordination not active
           source:
             description: Source of the status change
             type: string_list
@@ -1619,14 +1615,10 @@ objects:
             max: 255
           type:
             type: string
-            description: |-
+            values:
               new: New priority request
               update: Update to existing priority request
               cancel: Cancel an existing priority
-            values:
-              new:
-              update:
-              cancel:
           level:
             type: integer
             description: |-
@@ -1642,9 +1634,8 @@ objects:
           vehicleType:
             type: string
             optional: true
-            description: |-
-              Vehicle type
-
+            description: Vehicle type
+            values:
               pedestrian: Pedestrians
               bicycle: Bicycles
               motorcycle: Motorcycles
@@ -1657,19 +1648,6 @@ objects:
               safetyCar: For e.g. escort vehicles
               specialTransport: For e.g. heavy load
               other: Other type of vehicle
-            values:
-              pedestrian:
-              bicycle:
-              motorcycle:
-              car:
-              bus:
-              lightTruck:
-              heavyTruck:
-              tram:
-              emergency:
-              safetyCar:
-              specialTransport:
-              other:
         command: requestPriority
       M0023:
         description: |-


### PR DESCRIPTION
Use 'values' for description texts for individual enums, rather than using a long description text. This is more consistent with how its written for other commands, e.g. M0001.

Example:
Instead of writing this:
```yaml
          vehicleType:
            type: string
            optional: true
            description: |-
              Vehicle type

              pedestrian: Pedestrians
              bicycle: Bicycles
              motorcycle: Motorcycles
              car: Passenger vehicle
              bus: Bus used for public transport
              lightTruck: Light truck
              heavyTruck: Heavy truck
              tram: Trams used for Public transport
              emergency: Police, fire or ambulance
              safetyCar: For e.g. escort vehicles
              specialTransport: For e.g. heavy load
              other: Other type of vehicle
            values:
              pedestrian:
              bicycle:
              motorcycle:
              car:
              bus:
              lightTruck:
              heavyTruck:
              tram:
              emergency:
              safetyCar:
              specialTransport:
              other:
        command: requestPriority

```

Write this:
```yaml
          vehicleType:
            type: string
            optional: true
            description: Vehicle type
            values:
              pedestrian: Pedestrians
              bicycle: Bicycles
              motorcycle: Motorcycles
              car: Passenger vehicle
              bus: Bus used for public transport
              lightTruck: Light truck
              heavyTruck: Heavy truck
              tram: Trams used for Public transport
              emergency: Police, fire or ambulance
              safetyCar: For e.g. escort vehicles
              specialTransport: For e.g. heavy load
              other: Other type of vehicle
        command: requestPriority

```
