### PR TITLE
Fix truncated description text of M0023

### DIFF
--- a/schemas/tlc/1.1/sxl.yaml
+++ b/schemas/tlc/1.1/sxl.yaml
@@ -1656,6 +1656,7 @@ objects:
           Switch to a designated time plan if this timeout is reached due to lost connection with the supervisor.
           Disable by setting timeout to '0'.
           Used in conjunction with dynamic bands, M0014
+          Requires security code 2.
         arguments:
           status:
             type: integer


### PR DESCRIPTION
The M0023 description should have "requires security code 2" in order to stay consistent with other commands