### PR TITLE
Fix several issues with description M0013

### DIFF
--- a/schemas/tlc/1.1/sxl.yaml
+++ b/schemas/tlc/1.1/sxl.yaml
@@ -1279,37 +1279,33 @@ objects:
           - ‘Bits to set’ defines which bit(s) to set. ‘0’ if unsed
           - ‘Bits to unset’ defines which bit(s) to unset. ‘0’ if unused
 
-          Example 1: “3,4134,65” sets input 4,5,8,15 and unsets 3,9 - Input starts from no. 5 - “4134” is 1 0000 0010 0110 in binary, but since input starts from 3, it is shifted 3 bits, e.g. 1000 0001 0011 0000 which are bits 4,5,8,15 - “65” is 100 0001 in binary, but since input starts from 3, it is shifted 3 bits, e.g. 10 0000 1000 which are bits 3,9
+          Example 1:
+          “3,4134,65” sets input 4,5,8,15 and unsets 3,9
+          - Input starts from no. 5
+          - “4134” is 1 0000 0010 0110 in binary, but since input starts from 3, it is shifted 3 bits, e.g. 1000 0001 0011 0000 which are bits 4,5,8,15
+          - “65” is 100 0001 in binary, but since input starts from 3, it is shifted 3 bits, e.g. 10 0000 1000 which are bits 3,9
 
-          Example 2: “12,1,4” sets input 12 and unsets 14 - Input starts from no. 12 - “1” is 1 in binary, but since input starts at 12 it is shifted 12 bits, e.g. 1 0000 0000 0000, which is bit 12 - “4” is 100 in binary, but since input starts at 12 it is shifted 12 bits, e.g. 100 0000 0000 0000, which is bit 14
+          Example 2:
+          “12,1,4” sets input 12 and unsets 14
+          - Input starts from no. 12
+          - “1” is 1 in binary, but since input starts at 12 it is shifted 12 bits, e.g. 1 0000 0000 0000, which is bit 12
+          - “4” is 100 in binary, but since input starts at 12 it is shifted 12 bits, e.g. 100 0000 0000 0000, which is bit 14
 
           And both these examples could be sent in the same message as: “3,4143,65;12,1,4”
 
           Such a message would set input 4,5,8,12,15 and unset input 3,9,14
 
-          Example 3: “0,1,2” sets input 0 and unsets 1 - Input starts from 0 - “1” is 1 in binary, which is bit 0 - “2” is 10 in binary, which is bit 1
+          Example 3:
+          “0,1,2” sets input 0 and unsets 1
+          - Input starts from 0
+          - “1” is 1 in binary, which is bit 0
+          - “2” is 10 in binary, which is bit 1
         arguments:
           status:
             type: string
             description: |-
-              Sets/Unsets a block of 16 inputs at a time. Can be repeated to set several blocks of 16 inputs. Values are separated with comma. Blocks are separated with semicolon. Since semicolon breaks the SXL csv-format, colon, ":" is used in example below.
-              
-              Format: [Offset],[Bits to set],[Bits to unset]:…
-              
-              Offset sets where the 16 inputs starts from followed by two 16 bit values telling which bit to set and unset in binary format, i.e. first bit have value 1 and last bit have value 32768.
-              
-              Example 1:
-              "5, 4134, 65" sets input 6,7,10,17 = on and 5,11 = off
-              (Input starts from no. 5 and bit 1,2,5,12 = 1 and bit 0,6 = 0)
-              
-              Example 2:
-              "22, 1, 4" sets input 22 = on and 24 = off
-              (Input starts from no. 22 and bit 0 = 1 and bit 2 = 0)
-              
-              And both thease examples could be sent in the same message as:
-              "5,4143:65:22,1,4"
-              
-              Such a message would activate input 6,7,10,17,22 and deactivate input 5,11,24
+              Sets/Unsets a block of 16 inputs at a time. Can be repeated to set several blocks of 16 inputs. Values are separated with comma. Blocks are separated with semicolon.
+              Format: [Offset];[Bits to set];[Bits to unset];…
           securityCode:
             type: string
             description: Security code 2


### PR DESCRIPTION
- [x] Write examples on multiple lines. It was hard to read
- [x] Remove redundant (and incorrect) description of "status". It seems to been added by mistake