### PR TITLE
Support markdown format in description text

### DIFF
--- a/schemas/tlc/1.1/sxl.yaml
+++ b/schemas/tlc/1.1/sxl.yaml
@@ -723,23 +723,20 @@ objects:
           A list of priorities is returned, referred to by their request ids. The same request id can appear only once.
           All priorities are included in the list (not only the ones that have changed state since the last update). This is done regardless of whether the status is send in respond to a status request, or due to a status subscription, and also regardless of whether a status subscription uses an update interval, or send-on-change, or both.
           If you subscribe using an update interval, you’re not guaranteed to get all intermediate states. To guarantee that, send-on-change must be used when subscribing.
-          To understand how this status relates to ETSI/J2735, please see the wiki.
+          To understand how this status relates to ETSI/J2735, please see the [wiki](https://github.com/rsmp-nordic/rsmp_sxl_tr
+affic_lights/wiki/Signal-priority-and-ETSI-J2735)
           All priorities are send on every status update, regardless of whether an interval, or sendOnChange (or both) is used.
           When a priority reaches an end states (completed, timeout, rejected, cooldown or stale), it must be sent once on the next status update, then removed from the list.
           A request always starts in the ‘received’ state. The following table shows the possible state transitions:
 
-          ==========  =====================================
-          State       Possible next states
-          ==========  =====================================
-          received    queued, activated, rejected, cooldown
-          queued      activated, timeout
-          activated   completed, stale
-          completed
-          timeout
-          rejected
-          cooldown
-          stale
-          ==========  =====================================
+          State      | Possible next states
+          ---------- | -------------------------------------
+          received   | queued, activated, rejected, cooldown
+          queued     | activated, timeout
+          activated  | completed, stale
+          completed  |
+          timeout    |
+          rejected   |
         arguments:
           status:
             description: JSON array of priority status items

--- a/schemas/tlc/1.1/sxl.yaml
+++ b/schemas/tlc/1.1/sxl.yaml
@@ -723,8 +723,7 @@ objects:
           A list of priorities is returned, referred to by their request ids. The same request id can appear only once.
           All priorities are included in the list (not only the ones that have changed state since the last update). This is done regardless of whether the status is send in respond to a status request, or due to a status subscription, and also regardless of whether a status subscription uses an update interval, or send-on-change, or both.
           If you subscribe using an update interval, you’re not guaranteed to get all intermediate states. To guarantee that, send-on-change must be used when subscribing.
-          To understand how this status relates to ETSI/J2735, please see the [wiki](https://github.com/rsmp-nordic/rsmp_sxl_tr
-affic_lights/wiki/Signal-priority-and-ETSI-J2735)
+          To understand how this status relates to ETSI/J2735, please see the [wiki](https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/wiki/Signal-priority-and-ETSI-J2735).
           All priorities are send on every status update, regardless of whether an interval, or sendOnChange (or both) is used.
           When a priority reaches an end states (completed, timeout, rejected, cooldown or stale), it must be sent once on the next status update, then removed from the list.
           A request always starts in the ‘received’ state. The following table shows the possible state transitions:
@@ -1525,7 +1524,7 @@ affic_lights/wiki/Signal-priority-and-ETSI-J2735)
 
           The benefit of using this message over activating inputs or detector logics is that you can specify a priority level, vehicle type and estimated time of arrival. You can also update or cancel the request, and use the corresponding status message to track the status of the request, including how much priority was actually given.
 
-          To understand how this command relates to ETSI/J2735, please see the wiki.
+          To understand how this command relates to ETSI/J2735, please see the [wiki](https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/wiki/Signal-priority-and-ETSI-J2735).
 
           Activating signal priority is expected to provide more green time for a particular movement through the intersection, but the exact mechanism must typically be configured in the controller.
 

--- a/schemas/tlc/1.1/sxl.yaml
+++ b/schemas/tlc/1.1/sxl.yaml
@@ -737,6 +737,8 @@ affic_lights/wiki/Signal-priority-and-ETSI-J2735)
           completed  |
           timeout    |
           rejected   |
+          cooldown   |
+          stale      |
         arguments:
           status:
             description: JSON array of priority status items


### PR DESCRIPTION
I suggest adding support for markdown format in the description text. This allows more advanced formatting which will be shown in the online doc and pdf. Markdown is converted to RST (with sxl-tools) in the sxl repo.

This PR adds a link to the wiki in S0033 and updates the format of the table to markdown format (it used to be rst format)