### PR TITLE
Disable functional_position and functional_state

### DIFF
--- a/schemas/tlc/1.1/sxl.yaml
+++ b/schemas/tlc/1.1/sxl.yaml
@@ -34,8 +34,10 @@ objects:
           NOTE! When dark according to configuration the controller is considered to be in use
       8:
         title: Not Connected
-    functional_position: not used (set to null)
-    functional_state: not used (set to null)
+    functional_position:
+      enabled: false
+    functional_state:
+      enabled: false
     alarms:
       A0001:
         description: |-

--- a/schemas/tlc/1.1/sxl.yaml
+++ b/schemas/tlc/1.1/sxl.yaml
@@ -34,10 +34,8 @@ objects:
           NOTE! When dark according to configuration the controller is considered to be in use
       8:
         title: Not Connected
-    functional_position:
-      enabled: false
-    functional_state:
-      enabled: false
+    functional_position: null
+    functional_state: null
     alarms:
       A0001:
         description: |-


### PR DESCRIPTION
As discussed in https://github.com/rsmp-nordic/rsmp_schema/issues/27, functional_position and functional_state needs to be treated as a set of enums.

However, in the TLC SXL they are not used, so I suggest adding `enabled: false` instead of using a description text `functionalPosition and functionalState not used (set to null)`