### PR TITLE
Add missing max speed in traffic counting

### DIFF
--- a/schemas/tlc/1.1/sxl.yaml
+++ b/schemas/tlc/1.1/sxl.yaml
@@ -2006,6 +2006,7 @@ objects:
             type: integer
             description: Average speed in km/h
             min: 0
+            max: 65535
       S0203:
         description: |-
           Traffic Counting: Occupancy.


### PR DESCRIPTION
The maximum possible speed value in traffic counting S0202 is missing