### PR TITLE
Add information about comma separated lists in descriptions

### DIFF
--- a/schemas/tlc/1.1/sxl.yaml
+++ b/schemas/tlc/1.1/sxl.yaml
@@ -240,6 +240,7 @@ objects:
           The controller is active and is not in dark mode.
           Used to determine if the controller is operating, e.g. it shows red, green or yellow to the vehicles.
           During maintenance work the controller might be using dark mode (no output to the signal heads).
+          Please note that all values in this status uses comma-separated lists - one value for each intersection, e.g. "0" and "True" (one intersection) or "1,2" and "True,False" (two intersections).
         arguments:
           intersection:
             type: integer_list
@@ -268,6 +269,7 @@ objects:
           Manual control.
           Traffic control deactivated in controller.
           Signal timings is controlled manually by service personnel using the operating panel of the controller.
+          Please note that all values in this status uses comma-separated lists - one value for each intersection, e.g. "0" and "True" (one intersection) or "1,2" and "True,False" (two intersections).
         arguments:
           intersection:
             type: integer_list
@@ -296,6 +298,7 @@ objects:
           Fixed time control.
           Traffic actuated control deactivated and a pre-timed control is used.
           Usually only used in case normal detectors can't be used, e.g. during maintenance work.
+          Please note that all values in this status uses comma-separated lists - one value for each intersection, e.g. "0" and "True" (one intersection) or "1,2" and "True,False" (two intersections).
         arguments:
           intersection:
             type: integer_list
@@ -324,6 +327,7 @@ objects:
           Isolated control.
           Isolated control mode indicates that the controller operates independently of any other traffic light controller. This may be different depending on traffic program (time plan).
           Used to determine if the controller is operating independently or operating with other controllers (coordination).
+          Please note that all values in this status uses comma-separated lists - one value for each intersection, e.g. "0" and "True" (one intersection) or "1,2" and "True,False" (two intersections).
         arguments:
           intersection:
             type: integer_list
@@ -353,6 +357,7 @@ objects:
           The controller shows yellow flash.
           Yellow flash may be used during a serious fault (depending on configuration) or maintenance work. It can also be manually set using M0001.
           Some countries may use yellow flash as an normal operating mode, and not necessarily during fault.
+          Please note that all values in this status uses comma-separated lists - one value for each intersection, e.g. "1,2" and "True,False"
         arguments:
           intersection:
             type: integer_list
@@ -381,6 +386,7 @@ objects:
           All red.
           The controller show all red.
           All red can be manually set using the controllers operating panel during maintenance work.
+          Please note that all values in this status uses comma-separated lists - one value for each intersection, e.g. "1,2" and "True,False"
         arguments:
           intersection:
             type: integer_list
@@ -409,6 +415,7 @@ objects:
           Police key
           The controller is forced to dark mode or yellow flash.
           The "police key" is a external control switch present in some controllers that manually switches the controller to either dark mode or yellow flash.
+          Please note that all values in this status uses comma-separated lists - one value for each intersection, e.g. "1,2" and "0,1"
         arguments:
           intersection:
             type: integer_list
@@ -511,6 +518,7 @@ objects:
         description: |-
           Control mode.
           Can be used for the management system to check the current control mode (startup, normal, standby, failure, test).
+          Please note that all values in this status uses comma-separated lists - one value for each intersection, e.g. "1,2" and "startup,control"
         arguments:
           intersection:
             type: integer_list


### PR DESCRIPTION
A couple of statuses use comma separated lists to send multiple values. In most cases it is important that all arguments are included as comma separated. This PR adds information in the description about this.

This information has been included since earlier, see for example: [Police Key](https://rsmp-nordic.org/rsmp_specifications/rsmp_sxl_traffic_lights/1.1/sxl_traffic_light_controller.html#s0013).