### PR TITLE
Add S0035 "emergency route" for supporting multiple active routes

### DIFF
--- a/schemas/tlc/1.1.1/sxl.yaml
+++ b/schemas/tlc/1.1.1/sxl.yaml
@@ -220,18 +220,18 @@ objects:
               True: Controller is currently in start up mode
       S0006:
         description: |-
-          Emergency route.
+          Emergency stage.
           The status is active during emergency prioritization.
           Used in situations where full priority is given in the emergency vehicle program.
         arguments:
           status:
             type: boolean
             description: |-
-              False: Emergency route inactive
-              True: Emergency route active
+              False: Emergency stage inactive
+              True: Emergency stage active
           emergencystage:
             type: integer
-            description: Number of emergency route
+            description: Number of emergency stage
             min: 1
             max: 255
       S0007:

--- a/schemas/tlc/1.1.1/sxl.yaml
+++ b/schemas/tlc/1.1.1/sxl.yaml
@@ -811,17 +811,12 @@ objects:
           This status is similar to S0006, but supports multiple routes
         arguments:
           emergencyroutes:
-            description: Emergency routes
+            description: Active emergency routes
             type: array
             items:
-              active:
-                type: boolean
-                description: |-
-                  False: Emergency route inactive
-                  True: Emergency route active
               id:
                 type: integer
-                description: ID of emergency route
+                description: ID of active emergency route
                 min: 1
                 max: 255
       S0091:

--- a/schemas/tlc/1.1.1/sxl.yaml
+++ b/schemas/tlc/1.1.1/sxl.yaml
@@ -802,6 +802,28 @@ objects:
             description: Timeout, in minutes
             min: 0
             max: 65535
+      S0035:
+        description: |-
+          Emergency route.
+          The status is active during emergency prioritization.
+          Used in situations where full priority is given in the emergency vehicle program.
+
+          This status is similar to S0006, but supports multiple routes
+        arguments:
+          emergencyroutes:
+            description: Emergency routes
+            type: array
+            items:
+              active:
+                type: boolean
+                description: |-
+                  False: Emergency route inactive
+                  True: Emergency route active
+              id:
+                type: integer
+                description: ID of emergency route
+                min: 1
+                max: 255
       S0091:
         description: |-
           Operator logged in/out OP-panel.

--- a/schemas/tlc/1.1.1/sxl.yaml
+++ b/schemas/tlc/1.1.1/sxl.yaml
@@ -220,18 +220,18 @@ objects:
               True: Controller is currently in start up mode
       S0006:
         description: |-
-          Emergency stage.
+          Emergency route.
           The status is active during emergency prioritization.
           Used in situations where full priority is given in the emergency vehicle program.
         arguments:
           status:
             type: boolean
             description: |-
-              False: Emergency stage inactive
-              True: Emergency stage active
+              False: Emergency route inactive
+              True: Emergency route active
           emergencystage:
             type: integer
-            description: Number of emergency stage
+            description: Number of emergency route
             min: 1
             max: 255
       S0007:


### PR DESCRIPTION
- [x] Create a new status S0035 for emergency route for TLC's that supports multiple active routes (array)
- [x] Rename S0006 "emegency stage" to "emergency route" to stay consistent and avoid confusion
- [ ] Perhaps consider S0006 as deprecated?

Discussion in https://github.com/rsmp-nordic/rsmp_validator/issues/270

Needs further discussion before merging