### PR TITLE
allow s0006 emergecystage=0

### DIFF
--- a/schemas/tlc/1.1.1/sxl.yaml
+++ b/schemas/tlc/1.1.1/sxl.yaml
@@ -218,11 +218,12 @@ objects:
             description: |-
               False: Controller is not in start up mode
               True: Controller is currently in start up mode
-      S0006:
+            S0006:
         description: |-
-          Emergency stage.
+          Emergency route.
           The status is active during emergency prioritization.
           Used in situations where full priority is given in the emergency vehicle program.
+          If no emergency route is active, status should be set to False, and emergencystage to zero.
         arguments:
           status:
             type: boolean
@@ -231,8 +232,8 @@ objects:
               True: Emergency stage active
           emergencystage:
             type: integer
-            description: Number of emergency stage
-            min: 1
+            description: Number of emergency stage (set to zero is no route is active)
+            min: 0
             max: 255
       S0007:
         description: |-


### PR DESCRIPTION
Allow emergencystage=0 in S0006 and explain that when status=False,  emergencystage should be set to zero.

Note that minimum and maximum values are currently not validated using json schema, because numerical values send as string, rather than as native json numericals. Once we use native data types, we can validate min/max values.

So this is more of an documentation issue.