### PR TITLE
Fix broken YAML

### DIFF
--- a/schemas/tlc/1.1/sxl.yaml
+++ b/schemas/tlc/1.1/sxl.yaml
@@ -1888,8 +1888,9 @@ objects:
             type: string
             description: Detector forced on/off while detector error
             values:
-              'on':    # on/off must be quoted, otherwise they are converted to true/false
-              'off':
+              # on/off must be quoted, otherwise they are converted to true/false
+              'on': ''
+              'off': ''
           manual:
             type: boolean
             description: Manually controlled detector logic (True/False)


### PR DESCRIPTION
There is a slight error with A0301 where 'on' and 'off' is written as a key value pair, but only the first part exists.
E.g.
```
'on':
'off':
```
But needs to be:
```
'on': ''
'off': ''
```
An alternative would be to write it as `[ 'on', 'off' ]`, but that is treated as an array. Both variants exists in the YAML. Perhaps we should only use key/value pairs?