### PR TITLE
Status response q undefined

### DIFF
--- a/lib/rsmp_schema/convert/export/json_schema.rb
+++ b/lib/rsmp_schema/convert/export/json_schema.rb
@@ -22,7 +22,7 @@ module RSMP
         end
 
         # convert a yaml item to json schema
-        def self.build_value item, can_be_null: false
+        def self.build_value item
           out = {}
           out['description'] = item['description'] if item['description']
           if item['type'] =~/_list$/
@@ -32,12 +32,7 @@ module RSMP
             handle_enum item, out
             handle_pattern item, out
           end
-          wrapped = wrap_refs out
-          if can_be_null
-            {"oneOf"=>[wrapped,{'type'=>'null'}] }
-          else
-            wrapped
-          end
+          wrap_refs out
         end
 
         # convert an item which is not a string-list, to json schema
@@ -140,14 +135,18 @@ module RSMP
         end
 
         # convert yaml alarm/status/command item to corresponding jsons schema
-        def self.build_item item, property_key: 'v', can_be_null: false
+        def self.build_item item, property_key: 'v'
           json = { "allOf" => [ { "description" => item['description'] } ] }
           if item['arguments']
+            json["allOf"] << {
+              "if"=> { "required" => ["q"], "properties" => { "q"=> { "const" => "undefined" }}},
+              "then" => { "s" => nil }
+            }
             json["allOf"].first["properties"] = { "n" => { "enum" => item['arguments'].keys.sort } }
             item['arguments'].each_pair do |key,argument|
               json["allOf"] << {
                 "if" => { "required" => ["n"], "properties" => { "n" => { "const" => key }}},
-                "then" => { "properties" => { property_key => build_value(argument, can_be_null: can_be_null) } }
+                "then" => { "properties" => { property_key => build_value(argument) } }
               }
             end
           end
@@ -179,7 +178,7 @@ module RSMP
         end
 
         # convert statuses to json schema
-        def self.output_statuses out, items, options
+        def self.output_statuses out, items
           list = [ { "properties" => { "sCI" => { "enum"=> items.keys.sort }}} ]
           items.keys.sort.each do |key|
             list << {
@@ -189,19 +188,17 @@ module RSMP
           end
           json = { "properties" => { "sS" => { "items" => { "allOf" => list }}}}
           out['statuses/statuses.json'] = output_json json
-          items.each_pair { |key,item| output_status out, key, item, options }
+          items.each_pair { |key,item| output_status out, key, item }
         end
 
         # convert a status to json schema
-        def self.output_status out, key, item, options
-          can_be_null = options["version"]
-          p can_be_null
-          json = build_item item, property_key:'s', can_be_null: true
+        def self.output_status out, key, item
+          json = build_item item, property_key: 's'
           out["statuses/#{key}.json"] = output_json json
         end
 
         # convert commands to json schema
-        def self.output_commands out, items, options
+        def self.output_commands out, items
           list = [ { "properties" => { "cCI" => { "enum"=> items.keys.sort }}} ]
           items.keys.sort.each do |key|
             list << {
@@ -218,7 +215,7 @@ module RSMP
           json = { "properties" => { "rvs" => { "$ref" => "commands.json" }}}
           out['commands/command_responses.json'] = output_json json
 
-          items.each_pair { |key,item| output_command out, key, item, options }
+          items.each_pair { |key,item| output_command out, key, item }
         end
 
         # convert a command to json schema
@@ -261,8 +258,8 @@ module RSMP
           out = {}
           output_root out, sxl[:meta]
           output_alarms out, sxl[:alarms]
-          output_statuses out, sxl[:statuses], sxl[:meta]
-          output_commands out, sxl[:commands], sxl[:meta]
+          output_statuses out, sxl[:statuses]
+          output_commands out, sxl[:commands]
           out
         end
 

--- a/schemas/core/3.1.2/status_response.json
+++ b/schemas/core/3.1.2/status_response.json
@@ -16,7 +16,7 @@
           "n" : { "description" : "Unique reference of the value", "type" : "string" },
           "s" : { "description" : "Value", "type" : "string" },
           "q" : {
-            "description" : "Value",
+            "description" : "Quality",
             "type" : "string",
             "enum" : [ "recent", "old", "undefined", "unknown" ]
           }

--- a/schemas/core/3.1.3/status_response.json
+++ b/schemas/core/3.1.3/status_response.json
@@ -11,18 +11,35 @@
       "minItems": 1,
       "items" : {
         "type" : "object",
-        "properties": {
-          "sCI" : { "$ref": "../3.1.2/definitions.json#/status_code" },
-          "n" : { "description" : "Unique reference of the value", "type" : "string" },
-          "s" : { "description" : "Value", "type" : "string" },
-          "q" : { 
-            "description" : "Value",
-            "type" : "string",
-            "enum" : [ "recent", "old", "undefined", "unknown" ]  // 'undefined' was added
+        "oneOf" : [
+          {
+            "properties": {
+              "sCI" : { "$ref": "../3.1.2/definitions.json#/status_code" },
+              "n" : { "description" : "Unique reference of the value", "type" : "string" },
+              "s" : { "description" : "Value", "type" : "string" },
+              "q" : { 
+                "description" : "Value",
+                "type" : "string",
+                "enum" : [ "recent", "old", "unknown" ]
+              }
+            },
+            "additionalProperties" : false
+          },
+          {
+            "properties": {
+              "sCI" : { "$ref": "../3.1.2/definitions.json#/status_code" },
+              "n" : { "description" : "Unique reference of the value", "type" : "string" },
+              "s" : { "description" : "Null when q=undefined", "type" : "null" },
+              "q" : { 
+                "description" : "Quality",
+                "type" : "string",
+                "const" : "undefined"       // 'undefined' was added
+              }
+            },
+            "additionalProperties" : false
           }
-        },
-        "required" : [ "sCI", "n", "s", "q" ],
-        "additionalProperties": false
+        ],
+        "required" : [ "sCI", "n", "s", "q" ]
       }
     }
   },

--- a/schemas/core/3.2/status_response.json
+++ b/schemas/core/3.2/status_response.json
@@ -11,18 +11,35 @@
       "minItems": 1,
       "items" : {
         "type" : "object",
-        "properties": {
-          "sCI" : { "$ref": "../3.1.2/definitions.json#/status_code" },
-          "n" : { "description" : "Unique reference of the value", "type" : "string" },
-          "s" : { "description" : "Value", "type" : ["string"," array"] },  // 3.2 allow arrays
-          "q" : { 
-            "description" : "Value",
-            "type" : "string",
-            "enum" : [ "recent", "old", "undefined", "unknown" ]
+        "oneOf" : [
+          {
+            "properties": {
+              "sCI" : { "$ref": "../3.1.2/definitions.json#/status_code" },
+              "n" : { "description" : "Unique reference of the value", "type" : "string" },
+              "s" : { "description" : "Value", "type" : ["string"," array"] },      // 3.2 allows array
+              "q" : { 
+                "description" : "Value",
+                "type" : "string",
+                "enum" : [ "recent", "old", "unknown" ]
+              }
+            },
+            "additionalProperties" : false
+          },
+          {
+            "properties": {
+              "sCI" : { "$ref": "../3.1.2/definitions.json#/status_code" },
+              "n" : { "description" : "Unique reference of the value", "type" : "string" },
+              "s" : { "description" : "Null when q=undefined", "type" : "null" },
+              "q" : { 
+                "description" : "Quality",
+                "type" : "string",
+                "const" : "undefined"
+              }
+            },
+            "additionalProperties" : false
           }
-        },
-        "required" : [ "sCI", "n", "s", "q" ],
-        "additionalProperties": false
+        ],
+        "required" : [ "sCI", "n", "s", "q" ]
       }
     }
   },

--- a/schemas/tlc/1.0.10/alarms/A0008.json
+++ b/schemas/tlc/1.0.10/alarms/A0008.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/alarms/A0201.json
+++ b/schemas/tlc/1.0.10/alarms/A0201.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/alarms/A0202.json
+++ b/schemas/tlc/1.0.10/alarms/A0202.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/alarms/A0301.json
+++ b/schemas/tlc/1.0.10/alarms/A0301.json
@@ -16,6 +16,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/alarms/A0302.json
+++ b/schemas/tlc/1.0.10/alarms/A0302.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/commands/M0001.json
+++ b/schemas/tlc/1.0.10/commands/M0001.json
@@ -19,6 +19,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/commands/M0002.json
+++ b/schemas/tlc/1.0.10/commands/M0002.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/commands/M0003.json
+++ b/schemas/tlc/1.0.10/commands/M0003.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/commands/M0004.json
+++ b/schemas/tlc/1.0.10/commands/M0004.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/commands/M0005.json
+++ b/schemas/tlc/1.0.10/commands/M0005.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/commands/M0006.json
+++ b/schemas/tlc/1.0.10/commands/M0006.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/commands/M0007.json
+++ b/schemas/tlc/1.0.10/commands/M0007.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/commands/M0008.json
+++ b/schemas/tlc/1.0.10/commands/M0008.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/commands/M0010.json
+++ b/schemas/tlc/1.0.10/commands/M0010.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/commands/M0011.json
+++ b/schemas/tlc/1.0.10/commands/M0011.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/commands/M0012.json
+++ b/schemas/tlc/1.0.10/commands/M0012.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/commands/M0013.json
+++ b/schemas/tlc/1.0.10/commands/M0013.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/commands/M0019.json
+++ b/schemas/tlc/1.0.10/commands/M0019.json
@@ -19,6 +19,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/commands/M0103.json
+++ b/schemas/tlc/1.0.10/commands/M0103.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/commands/M0104.json
+++ b/schemas/tlc/1.0.10/commands/M0104.json
@@ -22,6 +22,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0001.json
+++ b/schemas/tlc/1.0.10/statuses/S0001.json
@@ -16,6 +16,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0002.json
+++ b/schemas/tlc/1.0.10/statuses/S0002.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0003.json
+++ b/schemas/tlc/1.0.10/statuses/S0003.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0004.json
+++ b/schemas/tlc/1.0.10/statuses/S0004.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0005.json
+++ b/schemas/tlc/1.0.10/statuses/S0005.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0006.json
+++ b/schemas/tlc/1.0.10/statuses/S0006.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0007.json
+++ b/schemas/tlc/1.0.10/statuses/S0007.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0008.json
+++ b/schemas/tlc/1.0.10/statuses/S0008.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0009.json
+++ b/schemas/tlc/1.0.10/statuses/S0009.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0010.json
+++ b/schemas/tlc/1.0.10/statuses/S0010.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0011.json
+++ b/schemas/tlc/1.0.10/statuses/S0011.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0012.json
+++ b/schemas/tlc/1.0.10/statuses/S0012.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0013.json
+++ b/schemas/tlc/1.0.10/statuses/S0013.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0014.json
+++ b/schemas/tlc/1.0.10/statuses/S0014.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0015.json
+++ b/schemas/tlc/1.0.10/statuses/S0015.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0016.json
+++ b/schemas/tlc/1.0.10/statuses/S0016.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0017.json
+++ b/schemas/tlc/1.0.10/statuses/S0017.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0018.json
+++ b/schemas/tlc/1.0.10/statuses/S0018.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0019.json
+++ b/schemas/tlc/1.0.10/statuses/S0019.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0020.json
+++ b/schemas/tlc/1.0.10/statuses/S0020.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0021.json
+++ b/schemas/tlc/1.0.10/statuses/S0021.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0091.json
+++ b/schemas/tlc/1.0.10/statuses/S0091.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0092.json
+++ b/schemas/tlc/1.0.10/statuses/S0092.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0095.json
+++ b/schemas/tlc/1.0.10/statuses/S0095.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0096.json
+++ b/schemas/tlc/1.0.10/statuses/S0096.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0201.json
+++ b/schemas/tlc/1.0.10/statuses/S0201.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0202.json
+++ b/schemas/tlc/1.0.10/statuses/S0202.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0203.json
+++ b/schemas/tlc/1.0.10/statuses/S0203.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.10/statuses/S0204.json
+++ b/schemas/tlc/1.0.10/statuses/S0204.json
@@ -22,6 +22,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/alarms/A0008.json
+++ b/schemas/tlc/1.0.13/alarms/A0008.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/alarms/A0201.json
+++ b/schemas/tlc/1.0.13/alarms/A0201.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/alarms/A0202.json
+++ b/schemas/tlc/1.0.13/alarms/A0202.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/alarms/A0301.json
+++ b/schemas/tlc/1.0.13/alarms/A0301.json
@@ -16,6 +16,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/alarms/A0302.json
+++ b/schemas/tlc/1.0.13/alarms/A0302.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/commands/M0001.json
+++ b/schemas/tlc/1.0.13/commands/M0001.json
@@ -19,6 +19,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/commands/M0002.json
+++ b/schemas/tlc/1.0.13/commands/M0002.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/commands/M0003.json
+++ b/schemas/tlc/1.0.13/commands/M0003.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/commands/M0004.json
+++ b/schemas/tlc/1.0.13/commands/M0004.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/commands/M0005.json
+++ b/schemas/tlc/1.0.13/commands/M0005.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/commands/M0006.json
+++ b/schemas/tlc/1.0.13/commands/M0006.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/commands/M0007.json
+++ b/schemas/tlc/1.0.13/commands/M0007.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/commands/M0008.json
+++ b/schemas/tlc/1.0.13/commands/M0008.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/commands/M0010.json
+++ b/schemas/tlc/1.0.13/commands/M0010.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/commands/M0011.json
+++ b/schemas/tlc/1.0.13/commands/M0011.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/commands/M0012.json
+++ b/schemas/tlc/1.0.13/commands/M0012.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/commands/M0013.json
+++ b/schemas/tlc/1.0.13/commands/M0013.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/commands/M0014.json
+++ b/schemas/tlc/1.0.13/commands/M0014.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/commands/M0015.json
+++ b/schemas/tlc/1.0.13/commands/M0015.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/commands/M0016.json
+++ b/schemas/tlc/1.0.13/commands/M0016.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/commands/M0017.json
+++ b/schemas/tlc/1.0.13/commands/M0017.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/commands/M0018.json
+++ b/schemas/tlc/1.0.13/commands/M0018.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/commands/M0019.json
+++ b/schemas/tlc/1.0.13/commands/M0019.json
@@ -19,6 +19,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/commands/M0103.json
+++ b/schemas/tlc/1.0.13/commands/M0103.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/commands/M0104.json
+++ b/schemas/tlc/1.0.13/commands/M0104.json
@@ -22,6 +22,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0001.json
+++ b/schemas/tlc/1.0.13/statuses/S0001.json
@@ -16,6 +16,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0002.json
+++ b/schemas/tlc/1.0.13/statuses/S0002.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0003.json
+++ b/schemas/tlc/1.0.13/statuses/S0003.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0004.json
+++ b/schemas/tlc/1.0.13/statuses/S0004.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0005.json
+++ b/schemas/tlc/1.0.13/statuses/S0005.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0006.json
+++ b/schemas/tlc/1.0.13/statuses/S0006.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0007.json
+++ b/schemas/tlc/1.0.13/statuses/S0007.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0008.json
+++ b/schemas/tlc/1.0.13/statuses/S0008.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0009.json
+++ b/schemas/tlc/1.0.13/statuses/S0009.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0010.json
+++ b/schemas/tlc/1.0.13/statuses/S0010.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0011.json
+++ b/schemas/tlc/1.0.13/statuses/S0011.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0012.json
+++ b/schemas/tlc/1.0.13/statuses/S0012.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0013.json
+++ b/schemas/tlc/1.0.13/statuses/S0013.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0014.json
+++ b/schemas/tlc/1.0.13/statuses/S0014.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0015.json
+++ b/schemas/tlc/1.0.13/statuses/S0015.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0016.json
+++ b/schemas/tlc/1.0.13/statuses/S0016.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0017.json
+++ b/schemas/tlc/1.0.13/statuses/S0017.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0018.json
+++ b/schemas/tlc/1.0.13/statuses/S0018.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0019.json
+++ b/schemas/tlc/1.0.13/statuses/S0019.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0020.json
+++ b/schemas/tlc/1.0.13/statuses/S0020.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0021.json
+++ b/schemas/tlc/1.0.13/statuses/S0021.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0022.json
+++ b/schemas/tlc/1.0.13/statuses/S0022.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0023.json
+++ b/schemas/tlc/1.0.13/statuses/S0023.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0024.json
+++ b/schemas/tlc/1.0.13/statuses/S0024.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0025.json
+++ b/schemas/tlc/1.0.13/statuses/S0025.json
@@ -20,6 +20,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0026.json
+++ b/schemas/tlc/1.0.13/statuses/S0026.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0027.json
+++ b/schemas/tlc/1.0.13/statuses/S0027.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0028.json
+++ b/schemas/tlc/1.0.13/statuses/S0028.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0029.json
+++ b/schemas/tlc/1.0.13/statuses/S0029.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0091.json
+++ b/schemas/tlc/1.0.13/statuses/S0091.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0092.json
+++ b/schemas/tlc/1.0.13/statuses/S0092.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0095.json
+++ b/schemas/tlc/1.0.13/statuses/S0095.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0096.json
+++ b/schemas/tlc/1.0.13/statuses/S0096.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0201.json
+++ b/schemas/tlc/1.0.13/statuses/S0201.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0202.json
+++ b/schemas/tlc/1.0.13/statuses/S0202.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0203.json
+++ b/schemas/tlc/1.0.13/statuses/S0203.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.13/statuses/S0204.json
+++ b/schemas/tlc/1.0.13/statuses/S0204.json
@@ -22,6 +22,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/alarms/A0008.json
+++ b/schemas/tlc/1.0.14/alarms/A0008.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/alarms/A0201.json
+++ b/schemas/tlc/1.0.14/alarms/A0201.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/alarms/A0202.json
+++ b/schemas/tlc/1.0.14/alarms/A0202.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/alarms/A0301.json
+++ b/schemas/tlc/1.0.14/alarms/A0301.json
@@ -16,6 +16,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/alarms/A0302.json
+++ b/schemas/tlc/1.0.14/alarms/A0302.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/commands/M0001.json
+++ b/schemas/tlc/1.0.14/commands/M0001.json
@@ -19,6 +19,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/commands/M0002.json
+++ b/schemas/tlc/1.0.14/commands/M0002.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/commands/M0003.json
+++ b/schemas/tlc/1.0.14/commands/M0003.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/commands/M0004.json
+++ b/schemas/tlc/1.0.14/commands/M0004.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/commands/M0005.json
+++ b/schemas/tlc/1.0.14/commands/M0005.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/commands/M0006.json
+++ b/schemas/tlc/1.0.14/commands/M0006.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/commands/M0007.json
+++ b/schemas/tlc/1.0.14/commands/M0007.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/commands/M0008.json
+++ b/schemas/tlc/1.0.14/commands/M0008.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/commands/M0010.json
+++ b/schemas/tlc/1.0.14/commands/M0010.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/commands/M0011.json
+++ b/schemas/tlc/1.0.14/commands/M0011.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/commands/M0012.json
+++ b/schemas/tlc/1.0.14/commands/M0012.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/commands/M0013.json
+++ b/schemas/tlc/1.0.14/commands/M0013.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/commands/M0014.json
+++ b/schemas/tlc/1.0.14/commands/M0014.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/commands/M0015.json
+++ b/schemas/tlc/1.0.14/commands/M0015.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/commands/M0016.json
+++ b/schemas/tlc/1.0.14/commands/M0016.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/commands/M0017.json
+++ b/schemas/tlc/1.0.14/commands/M0017.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/commands/M0018.json
+++ b/schemas/tlc/1.0.14/commands/M0018.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/commands/M0019.json
+++ b/schemas/tlc/1.0.14/commands/M0019.json
@@ -19,6 +19,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/commands/M0103.json
+++ b/schemas/tlc/1.0.14/commands/M0103.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/commands/M0104.json
+++ b/schemas/tlc/1.0.14/commands/M0104.json
@@ -22,6 +22,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0001.json
+++ b/schemas/tlc/1.0.14/statuses/S0001.json
@@ -16,6 +16,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0002.json
+++ b/schemas/tlc/1.0.14/statuses/S0002.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0003.json
+++ b/schemas/tlc/1.0.14/statuses/S0003.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0004.json
+++ b/schemas/tlc/1.0.14/statuses/S0004.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0005.json
+++ b/schemas/tlc/1.0.14/statuses/S0005.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0006.json
+++ b/schemas/tlc/1.0.14/statuses/S0006.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0007.json
+++ b/schemas/tlc/1.0.14/statuses/S0007.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0008.json
+++ b/schemas/tlc/1.0.14/statuses/S0008.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0009.json
+++ b/schemas/tlc/1.0.14/statuses/S0009.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0010.json
+++ b/schemas/tlc/1.0.14/statuses/S0010.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0011.json
+++ b/schemas/tlc/1.0.14/statuses/S0011.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0012.json
+++ b/schemas/tlc/1.0.14/statuses/S0012.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0013.json
+++ b/schemas/tlc/1.0.14/statuses/S0013.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0014.json
+++ b/schemas/tlc/1.0.14/statuses/S0014.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0015.json
+++ b/schemas/tlc/1.0.14/statuses/S0015.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0016.json
+++ b/schemas/tlc/1.0.14/statuses/S0016.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0017.json
+++ b/schemas/tlc/1.0.14/statuses/S0017.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0018.json
+++ b/schemas/tlc/1.0.14/statuses/S0018.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0019.json
+++ b/schemas/tlc/1.0.14/statuses/S0019.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0020.json
+++ b/schemas/tlc/1.0.14/statuses/S0020.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0021.json
+++ b/schemas/tlc/1.0.14/statuses/S0021.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0022.json
+++ b/schemas/tlc/1.0.14/statuses/S0022.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0023.json
+++ b/schemas/tlc/1.0.14/statuses/S0023.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0024.json
+++ b/schemas/tlc/1.0.14/statuses/S0024.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0025.json
+++ b/schemas/tlc/1.0.14/statuses/S0025.json
@@ -20,6 +20,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0026.json
+++ b/schemas/tlc/1.0.14/statuses/S0026.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0027.json
+++ b/schemas/tlc/1.0.14/statuses/S0027.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0028.json
+++ b/schemas/tlc/1.0.14/statuses/S0028.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0029.json
+++ b/schemas/tlc/1.0.14/statuses/S0029.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0091.json
+++ b/schemas/tlc/1.0.14/statuses/S0091.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0092.json
+++ b/schemas/tlc/1.0.14/statuses/S0092.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0095.json
+++ b/schemas/tlc/1.0.14/statuses/S0095.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0096.json
+++ b/schemas/tlc/1.0.14/statuses/S0096.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0201.json
+++ b/schemas/tlc/1.0.14/statuses/S0201.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0202.json
+++ b/schemas/tlc/1.0.14/statuses/S0202.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0203.json
+++ b/schemas/tlc/1.0.14/statuses/S0203.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0204.json
+++ b/schemas/tlc/1.0.14/statuses/S0204.json
@@ -22,6 +22,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0205.json
+++ b/schemas/tlc/1.0.14/statuses/S0205.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0206.json
+++ b/schemas/tlc/1.0.14/statuses/S0206.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0207.json
+++ b/schemas/tlc/1.0.14/statuses/S0207.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.14/statuses/S0208.json
+++ b/schemas/tlc/1.0.14/statuses/S0208.json
@@ -22,6 +22,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/alarms/A0008.json
+++ b/schemas/tlc/1.0.15/alarms/A0008.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/alarms/A0201.json
+++ b/schemas/tlc/1.0.15/alarms/A0201.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/alarms/A0202.json
+++ b/schemas/tlc/1.0.15/alarms/A0202.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/alarms/A0301.json
+++ b/schemas/tlc/1.0.15/alarms/A0301.json
@@ -16,6 +16,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/alarms/A0302.json
+++ b/schemas/tlc/1.0.15/alarms/A0302.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/commands/M0001.json
+++ b/schemas/tlc/1.0.15/commands/M0001.json
@@ -19,6 +19,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/commands/M0002.json
+++ b/schemas/tlc/1.0.15/commands/M0002.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/commands/M0003.json
+++ b/schemas/tlc/1.0.15/commands/M0003.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/commands/M0004.json
+++ b/schemas/tlc/1.0.15/commands/M0004.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/commands/M0005.json
+++ b/schemas/tlc/1.0.15/commands/M0005.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/commands/M0006.json
+++ b/schemas/tlc/1.0.15/commands/M0006.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/commands/M0007.json
+++ b/schemas/tlc/1.0.15/commands/M0007.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/commands/M0008.json
+++ b/schemas/tlc/1.0.15/commands/M0008.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/commands/M0010.json
+++ b/schemas/tlc/1.0.15/commands/M0010.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/commands/M0011.json
+++ b/schemas/tlc/1.0.15/commands/M0011.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/commands/M0012.json
+++ b/schemas/tlc/1.0.15/commands/M0012.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/commands/M0013.json
+++ b/schemas/tlc/1.0.15/commands/M0013.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/commands/M0014.json
+++ b/schemas/tlc/1.0.15/commands/M0014.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/commands/M0015.json
+++ b/schemas/tlc/1.0.15/commands/M0015.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/commands/M0016.json
+++ b/schemas/tlc/1.0.15/commands/M0016.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/commands/M0017.json
+++ b/schemas/tlc/1.0.15/commands/M0017.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/commands/M0018.json
+++ b/schemas/tlc/1.0.15/commands/M0018.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/commands/M0019.json
+++ b/schemas/tlc/1.0.15/commands/M0019.json
@@ -19,6 +19,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/commands/M0020.json
+++ b/schemas/tlc/1.0.15/commands/M0020.json
@@ -19,6 +19,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/commands/M0021.json
+++ b/schemas/tlc/1.0.15/commands/M0021.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/commands/M0103.json
+++ b/schemas/tlc/1.0.15/commands/M0103.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/commands/M0104.json
+++ b/schemas/tlc/1.0.15/commands/M0104.json
@@ -22,6 +22,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0001.json
+++ b/schemas/tlc/1.0.15/statuses/S0001.json
@@ -16,6 +16,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0002.json
+++ b/schemas/tlc/1.0.15/statuses/S0002.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0003.json
+++ b/schemas/tlc/1.0.15/statuses/S0003.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0004.json
+++ b/schemas/tlc/1.0.15/statuses/S0004.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0005.json
+++ b/schemas/tlc/1.0.15/statuses/S0005.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0006.json
+++ b/schemas/tlc/1.0.15/statuses/S0006.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0007.json
+++ b/schemas/tlc/1.0.15/statuses/S0007.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0008.json
+++ b/schemas/tlc/1.0.15/statuses/S0008.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0009.json
+++ b/schemas/tlc/1.0.15/statuses/S0009.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0010.json
+++ b/schemas/tlc/1.0.15/statuses/S0010.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0011.json
+++ b/schemas/tlc/1.0.15/statuses/S0011.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0012.json
+++ b/schemas/tlc/1.0.15/statuses/S0012.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0013.json
+++ b/schemas/tlc/1.0.15/statuses/S0013.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0014.json
+++ b/schemas/tlc/1.0.15/statuses/S0014.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0015.json
+++ b/schemas/tlc/1.0.15/statuses/S0015.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0016.json
+++ b/schemas/tlc/1.0.15/statuses/S0016.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0017.json
+++ b/schemas/tlc/1.0.15/statuses/S0017.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0018.json
+++ b/schemas/tlc/1.0.15/statuses/S0018.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0019.json
+++ b/schemas/tlc/1.0.15/statuses/S0019.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0020.json
+++ b/schemas/tlc/1.0.15/statuses/S0020.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0021.json
+++ b/schemas/tlc/1.0.15/statuses/S0021.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0022.json
+++ b/schemas/tlc/1.0.15/statuses/S0022.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0023.json
+++ b/schemas/tlc/1.0.15/statuses/S0023.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0024.json
+++ b/schemas/tlc/1.0.15/statuses/S0024.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0025.json
+++ b/schemas/tlc/1.0.15/statuses/S0025.json
@@ -20,6 +20,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0026.json
+++ b/schemas/tlc/1.0.15/statuses/S0026.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0027.json
+++ b/schemas/tlc/1.0.15/statuses/S0027.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0028.json
+++ b/schemas/tlc/1.0.15/statuses/S0028.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0029.json
+++ b/schemas/tlc/1.0.15/statuses/S0029.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0030.json
+++ b/schemas/tlc/1.0.15/statuses/S0030.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0031.json
+++ b/schemas/tlc/1.0.15/statuses/S0031.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0091.json
+++ b/schemas/tlc/1.0.15/statuses/S0091.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0092.json
+++ b/schemas/tlc/1.0.15/statuses/S0092.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0095.json
+++ b/schemas/tlc/1.0.15/statuses/S0095.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0096.json
+++ b/schemas/tlc/1.0.15/statuses/S0096.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0097.json
+++ b/schemas/tlc/1.0.15/statuses/S0097.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0098.json
+++ b/schemas/tlc/1.0.15/statuses/S0098.json
@@ -15,6 +15,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0201.json
+++ b/schemas/tlc/1.0.15/statuses/S0201.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0202.json
+++ b/schemas/tlc/1.0.15/statuses/S0202.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0203.json
+++ b/schemas/tlc/1.0.15/statuses/S0203.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0204.json
+++ b/schemas/tlc/1.0.15/statuses/S0204.json
@@ -22,6 +22,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0205.json
+++ b/schemas/tlc/1.0.15/statuses/S0205.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0206.json
+++ b/schemas/tlc/1.0.15/statuses/S0206.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0207.json
+++ b/schemas/tlc/1.0.15/statuses/S0207.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.15/statuses/S0208.json
+++ b/schemas/tlc/1.0.15/statuses/S0208.json
@@ -22,6 +22,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/alarms/A0008.json
+++ b/schemas/tlc/1.0.7/alarms/A0008.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/alarms/A0201.json
+++ b/schemas/tlc/1.0.7/alarms/A0201.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/alarms/A0202.json
+++ b/schemas/tlc/1.0.7/alarms/A0202.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/alarms/A0301.json
+++ b/schemas/tlc/1.0.7/alarms/A0301.json
@@ -16,6 +16,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/alarms/A0302.json
+++ b/schemas/tlc/1.0.7/alarms/A0302.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/commands/M0001.json
+++ b/schemas/tlc/1.0.7/commands/M0001.json
@@ -19,6 +19,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/commands/M0002.json
+++ b/schemas/tlc/1.0.7/commands/M0002.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/commands/M0003.json
+++ b/schemas/tlc/1.0.7/commands/M0003.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/commands/M0004.json
+++ b/schemas/tlc/1.0.7/commands/M0004.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/commands/M0005.json
+++ b/schemas/tlc/1.0.7/commands/M0005.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/commands/M0006.json
+++ b/schemas/tlc/1.0.7/commands/M0006.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/commands/M0007.json
+++ b/schemas/tlc/1.0.7/commands/M0007.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/commands/M0008.json
+++ b/schemas/tlc/1.0.7/commands/M0008.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/commands/M0010.json
+++ b/schemas/tlc/1.0.7/commands/M0010.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/commands/M0011.json
+++ b/schemas/tlc/1.0.7/commands/M0011.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/commands/M0019.json
+++ b/schemas/tlc/1.0.7/commands/M0019.json
@@ -19,6 +19,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/commands/M0103.json
+++ b/schemas/tlc/1.0.7/commands/M0103.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/commands/M0104.json
+++ b/schemas/tlc/1.0.7/commands/M0104.json
@@ -22,6 +22,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0001.json
+++ b/schemas/tlc/1.0.7/statuses/S0001.json
@@ -16,6 +16,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0002.json
+++ b/schemas/tlc/1.0.7/statuses/S0002.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0003.json
+++ b/schemas/tlc/1.0.7/statuses/S0003.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0004.json
+++ b/schemas/tlc/1.0.7/statuses/S0004.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0005.json
+++ b/schemas/tlc/1.0.7/statuses/S0005.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0006.json
+++ b/schemas/tlc/1.0.7/statuses/S0006.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0007.json
+++ b/schemas/tlc/1.0.7/statuses/S0007.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0008.json
+++ b/schemas/tlc/1.0.7/statuses/S0008.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0009.json
+++ b/schemas/tlc/1.0.7/statuses/S0009.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0010.json
+++ b/schemas/tlc/1.0.7/statuses/S0010.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0011.json
+++ b/schemas/tlc/1.0.7/statuses/S0011.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0012.json
+++ b/schemas/tlc/1.0.7/statuses/S0012.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0013.json
+++ b/schemas/tlc/1.0.7/statuses/S0013.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0014.json
+++ b/schemas/tlc/1.0.7/statuses/S0014.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0015.json
+++ b/schemas/tlc/1.0.7/statuses/S0015.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0016.json
+++ b/schemas/tlc/1.0.7/statuses/S0016.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0017.json
+++ b/schemas/tlc/1.0.7/statuses/S0017.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0018.json
+++ b/schemas/tlc/1.0.7/statuses/S0018.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0019.json
+++ b/schemas/tlc/1.0.7/statuses/S0019.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0020.json
+++ b/schemas/tlc/1.0.7/statuses/S0020.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0021.json
+++ b/schemas/tlc/1.0.7/statuses/S0021.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0025.json
+++ b/schemas/tlc/1.0.7/statuses/S0025.json
@@ -20,6 +20,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0091.json
+++ b/schemas/tlc/1.0.7/statuses/S0091.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0092.json
+++ b/schemas/tlc/1.0.7/statuses/S0092.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0095.json
+++ b/schemas/tlc/1.0.7/statuses/S0095.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0096.json
+++ b/schemas/tlc/1.0.7/statuses/S0096.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0201.json
+++ b/schemas/tlc/1.0.7/statuses/S0201.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0202.json
+++ b/schemas/tlc/1.0.7/statuses/S0202.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0203.json
+++ b/schemas/tlc/1.0.7/statuses/S0203.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.7/statuses/S0204.json
+++ b/schemas/tlc/1.0.7/statuses/S0204.json
@@ -22,6 +22,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/alarms/A0008.json
+++ b/schemas/tlc/1.0.8/alarms/A0008.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/alarms/A0201.json
+++ b/schemas/tlc/1.0.8/alarms/A0201.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/alarms/A0202.json
+++ b/schemas/tlc/1.0.8/alarms/A0202.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/alarms/A0301.json
+++ b/schemas/tlc/1.0.8/alarms/A0301.json
@@ -16,6 +16,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/alarms/A0302.json
+++ b/schemas/tlc/1.0.8/alarms/A0302.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/commands/M0001.json
+++ b/schemas/tlc/1.0.8/commands/M0001.json
@@ -19,6 +19,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/commands/M0002.json
+++ b/schemas/tlc/1.0.8/commands/M0002.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/commands/M0003.json
+++ b/schemas/tlc/1.0.8/commands/M0003.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/commands/M0004.json
+++ b/schemas/tlc/1.0.8/commands/M0004.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/commands/M0005.json
+++ b/schemas/tlc/1.0.8/commands/M0005.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/commands/M0006.json
+++ b/schemas/tlc/1.0.8/commands/M0006.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/commands/M0007.json
+++ b/schemas/tlc/1.0.8/commands/M0007.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/commands/M0008.json
+++ b/schemas/tlc/1.0.8/commands/M0008.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/commands/M0010.json
+++ b/schemas/tlc/1.0.8/commands/M0010.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/commands/M0011.json
+++ b/schemas/tlc/1.0.8/commands/M0011.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/commands/M0012.json
+++ b/schemas/tlc/1.0.8/commands/M0012.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/commands/M0013.json
+++ b/schemas/tlc/1.0.8/commands/M0013.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/commands/M0019.json
+++ b/schemas/tlc/1.0.8/commands/M0019.json
@@ -19,6 +19,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/commands/M0103.json
+++ b/schemas/tlc/1.0.8/commands/M0103.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/commands/M0104.json
+++ b/schemas/tlc/1.0.8/commands/M0104.json
@@ -22,6 +22,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0001.json
+++ b/schemas/tlc/1.0.8/statuses/S0001.json
@@ -16,6 +16,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0002.json
+++ b/schemas/tlc/1.0.8/statuses/S0002.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0003.json
+++ b/schemas/tlc/1.0.8/statuses/S0003.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0004.json
+++ b/schemas/tlc/1.0.8/statuses/S0004.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0005.json
+++ b/schemas/tlc/1.0.8/statuses/S0005.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0006.json
+++ b/schemas/tlc/1.0.8/statuses/S0006.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0007.json
+++ b/schemas/tlc/1.0.8/statuses/S0007.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0008.json
+++ b/schemas/tlc/1.0.8/statuses/S0008.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0009.json
+++ b/schemas/tlc/1.0.8/statuses/S0009.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0010.json
+++ b/schemas/tlc/1.0.8/statuses/S0010.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0011.json
+++ b/schemas/tlc/1.0.8/statuses/S0011.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0012.json
+++ b/schemas/tlc/1.0.8/statuses/S0012.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0013.json
+++ b/schemas/tlc/1.0.8/statuses/S0013.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0014.json
+++ b/schemas/tlc/1.0.8/statuses/S0014.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0015.json
+++ b/schemas/tlc/1.0.8/statuses/S0015.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0016.json
+++ b/schemas/tlc/1.0.8/statuses/S0016.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0017.json
+++ b/schemas/tlc/1.0.8/statuses/S0017.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0018.json
+++ b/schemas/tlc/1.0.8/statuses/S0018.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0019.json
+++ b/schemas/tlc/1.0.8/statuses/S0019.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0020.json
+++ b/schemas/tlc/1.0.8/statuses/S0020.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0021.json
+++ b/schemas/tlc/1.0.8/statuses/S0021.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0091.json
+++ b/schemas/tlc/1.0.8/statuses/S0091.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0092.json
+++ b/schemas/tlc/1.0.8/statuses/S0092.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0095.json
+++ b/schemas/tlc/1.0.8/statuses/S0095.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0096.json
+++ b/schemas/tlc/1.0.8/statuses/S0096.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0201.json
+++ b/schemas/tlc/1.0.8/statuses/S0201.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0202.json
+++ b/schemas/tlc/1.0.8/statuses/S0202.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0203.json
+++ b/schemas/tlc/1.0.8/statuses/S0203.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.8/statuses/S0204.json
+++ b/schemas/tlc/1.0.8/statuses/S0204.json
@@ -22,6 +22,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/alarms/A0008.json
+++ b/schemas/tlc/1.0.9/alarms/A0008.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/alarms/A0201.json
+++ b/schemas/tlc/1.0.9/alarms/A0201.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/alarms/A0202.json
+++ b/schemas/tlc/1.0.9/alarms/A0202.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/alarms/A0301.json
+++ b/schemas/tlc/1.0.9/alarms/A0301.json
@@ -16,6 +16,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/alarms/A0302.json
+++ b/schemas/tlc/1.0.9/alarms/A0302.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/commands/M0001.json
+++ b/schemas/tlc/1.0.9/commands/M0001.json
@@ -19,6 +19,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/commands/M0002.json
+++ b/schemas/tlc/1.0.9/commands/M0002.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/commands/M0003.json
+++ b/schemas/tlc/1.0.9/commands/M0003.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/commands/M0004.json
+++ b/schemas/tlc/1.0.9/commands/M0004.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/commands/M0005.json
+++ b/schemas/tlc/1.0.9/commands/M0005.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/commands/M0006.json
+++ b/schemas/tlc/1.0.9/commands/M0006.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/commands/M0007.json
+++ b/schemas/tlc/1.0.9/commands/M0007.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/commands/M0008.json
+++ b/schemas/tlc/1.0.9/commands/M0008.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/commands/M0010.json
+++ b/schemas/tlc/1.0.9/commands/M0010.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/commands/M0011.json
+++ b/schemas/tlc/1.0.9/commands/M0011.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/commands/M0012.json
+++ b/schemas/tlc/1.0.9/commands/M0012.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/commands/M0013.json
+++ b/schemas/tlc/1.0.9/commands/M0013.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/commands/M0019.json
+++ b/schemas/tlc/1.0.9/commands/M0019.json
@@ -19,6 +19,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/commands/M0103.json
+++ b/schemas/tlc/1.0.9/commands/M0103.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/commands/M0104.json
+++ b/schemas/tlc/1.0.9/commands/M0104.json
@@ -22,6 +22,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0001.json
+++ b/schemas/tlc/1.0.9/statuses/S0001.json
@@ -16,6 +16,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0002.json
+++ b/schemas/tlc/1.0.9/statuses/S0002.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0003.json
+++ b/schemas/tlc/1.0.9/statuses/S0003.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0004.json
+++ b/schemas/tlc/1.0.9/statuses/S0004.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0005.json
+++ b/schemas/tlc/1.0.9/statuses/S0005.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0006.json
+++ b/schemas/tlc/1.0.9/statuses/S0006.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0007.json
+++ b/schemas/tlc/1.0.9/statuses/S0007.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0008.json
+++ b/schemas/tlc/1.0.9/statuses/S0008.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0009.json
+++ b/schemas/tlc/1.0.9/statuses/S0009.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0010.json
+++ b/schemas/tlc/1.0.9/statuses/S0010.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0011.json
+++ b/schemas/tlc/1.0.9/statuses/S0011.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0012.json
+++ b/schemas/tlc/1.0.9/statuses/S0012.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0013.json
+++ b/schemas/tlc/1.0.9/statuses/S0013.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0014.json
+++ b/schemas/tlc/1.0.9/statuses/S0014.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0015.json
+++ b/schemas/tlc/1.0.9/statuses/S0015.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0016.json
+++ b/schemas/tlc/1.0.9/statuses/S0016.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0017.json
+++ b/schemas/tlc/1.0.9/statuses/S0017.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0018.json
+++ b/schemas/tlc/1.0.9/statuses/S0018.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0019.json
+++ b/schemas/tlc/1.0.9/statuses/S0019.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0020.json
+++ b/schemas/tlc/1.0.9/statuses/S0020.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0021.json
+++ b/schemas/tlc/1.0.9/statuses/S0021.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0091.json
+++ b/schemas/tlc/1.0.9/statuses/S0091.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0092.json
+++ b/schemas/tlc/1.0.9/statuses/S0092.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0095.json
+++ b/schemas/tlc/1.0.9/statuses/S0095.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0096.json
+++ b/schemas/tlc/1.0.9/statuses/S0096.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0201.json
+++ b/schemas/tlc/1.0.9/statuses/S0201.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0202.json
+++ b/schemas/tlc/1.0.9/statuses/S0202.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0203.json
+++ b/schemas/tlc/1.0.9/statuses/S0203.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.0.9/statuses/S0204.json
+++ b/schemas/tlc/1.0.9/statuses/S0204.json
@@ -22,6 +22,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/alarms/A0007.json
+++ b/schemas/tlc/1.1/alarms/A0007.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/alarms/A0008.json
+++ b/schemas/tlc/1.1/alarms/A0008.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/alarms/A0201.json
+++ b/schemas/tlc/1.1/alarms/A0201.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/alarms/A0202.json
+++ b/schemas/tlc/1.1/alarms/A0202.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/alarms/A0301.json
+++ b/schemas/tlc/1.1/alarms/A0301.json
@@ -16,6 +16,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/alarms/A0302.json
+++ b/schemas/tlc/1.1/alarms/A0302.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/alarms/A0303.json
+++ b/schemas/tlc/1.1/alarms/A0303.json
@@ -16,6 +16,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/alarms/A0304.json
+++ b/schemas/tlc/1.1/alarms/A0304.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/commands/M0001.json
+++ b/schemas/tlc/1.1/commands/M0001.json
@@ -19,6 +19,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/commands/M0002.json
+++ b/schemas/tlc/1.1/commands/M0002.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/commands/M0003.json
+++ b/schemas/tlc/1.1/commands/M0003.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/commands/M0004.json
+++ b/schemas/tlc/1.1/commands/M0004.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/commands/M0005.json
+++ b/schemas/tlc/1.1/commands/M0005.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/commands/M0006.json
+++ b/schemas/tlc/1.1/commands/M0006.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/commands/M0007.json
+++ b/schemas/tlc/1.1/commands/M0007.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/commands/M0008.json
+++ b/schemas/tlc/1.1/commands/M0008.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/commands/M0010.json
+++ b/schemas/tlc/1.1/commands/M0010.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/commands/M0011.json
+++ b/schemas/tlc/1.1/commands/M0011.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/commands/M0012.json
+++ b/schemas/tlc/1.1/commands/M0012.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/commands/M0013.json
+++ b/schemas/tlc/1.1/commands/M0013.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/commands/M0014.json
+++ b/schemas/tlc/1.1/commands/M0014.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/commands/M0015.json
+++ b/schemas/tlc/1.1/commands/M0015.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/commands/M0016.json
+++ b/schemas/tlc/1.1/commands/M0016.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/commands/M0017.json
+++ b/schemas/tlc/1.1/commands/M0017.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/commands/M0018.json
+++ b/schemas/tlc/1.1/commands/M0018.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/commands/M0019.json
+++ b/schemas/tlc/1.1/commands/M0019.json
@@ -19,6 +19,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/commands/M0020.json
+++ b/schemas/tlc/1.1/commands/M0020.json
@@ -19,6 +19,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/commands/M0021.json
+++ b/schemas/tlc/1.1/commands/M0021.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/commands/M0022.json
+++ b/schemas/tlc/1.1/commands/M0022.json
@@ -27,6 +27,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/commands/M0023.json
+++ b/schemas/tlc/1.1/commands/M0023.json
@@ -17,6 +17,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/commands/M0103.json
+++ b/schemas/tlc/1.1/commands/M0103.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/commands/M0104.json
+++ b/schemas/tlc/1.1/commands/M0104.json
@@ -22,6 +22,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0001.json
+++ b/schemas/tlc/1.1/statuses/S0001.json
@@ -16,6 +16,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0002.json
+++ b/schemas/tlc/1.1/statuses/S0002.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0003.json
+++ b/schemas/tlc/1.1/statuses/S0003.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0004.json
+++ b/schemas/tlc/1.1/statuses/S0004.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0005.json
+++ b/schemas/tlc/1.1/statuses/S0005.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0006.json
+++ b/schemas/tlc/1.1/statuses/S0006.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0007.json
+++ b/schemas/tlc/1.1/statuses/S0007.json
@@ -15,6 +15,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0008.json
+++ b/schemas/tlc/1.1/statuses/S0008.json
@@ -15,6 +15,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0009.json
+++ b/schemas/tlc/1.1/statuses/S0009.json
@@ -15,6 +15,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0010.json
+++ b/schemas/tlc/1.1/statuses/S0010.json
@@ -15,6 +15,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0011.json
+++ b/schemas/tlc/1.1/statuses/S0011.json
@@ -15,6 +15,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0012.json
+++ b/schemas/tlc/1.1/statuses/S0012.json
@@ -15,6 +15,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0013.json
+++ b/schemas/tlc/1.1/statuses/S0013.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0014.json
+++ b/schemas/tlc/1.1/statuses/S0014.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0015.json
+++ b/schemas/tlc/1.1/statuses/S0015.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0016.json
+++ b/schemas/tlc/1.1/statuses/S0016.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0017.json
+++ b/schemas/tlc/1.1/statuses/S0017.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0018.json
+++ b/schemas/tlc/1.1/statuses/S0018.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0019.json
+++ b/schemas/tlc/1.1/statuses/S0019.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0020.json
+++ b/schemas/tlc/1.1/statuses/S0020.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0021.json
+++ b/schemas/tlc/1.1/statuses/S0021.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0022.json
+++ b/schemas/tlc/1.1/statuses/S0022.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0023.json
+++ b/schemas/tlc/1.1/statuses/S0023.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0024.json
+++ b/schemas/tlc/1.1/statuses/S0024.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0025.json
+++ b/schemas/tlc/1.1/statuses/S0025.json
@@ -20,6 +20,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0026.json
+++ b/schemas/tlc/1.1/statuses/S0026.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0027.json
+++ b/schemas/tlc/1.1/statuses/S0027.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0028.json
+++ b/schemas/tlc/1.1/statuses/S0028.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0029.json
+++ b/schemas/tlc/1.1/statuses/S0029.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0030.json
+++ b/schemas/tlc/1.1/statuses/S0030.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0031.json
+++ b/schemas/tlc/1.1/statuses/S0031.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0032.json
+++ b/schemas/tlc/1.1/statuses/S0032.json
@@ -15,6 +15,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0033.json
+++ b/schemas/tlc/1.1/statuses/S0033.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0034.json
+++ b/schemas/tlc/1.1/statuses/S0034.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0091.json
+++ b/schemas/tlc/1.1/statuses/S0091.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0092.json
+++ b/schemas/tlc/1.1/statuses/S0092.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0095.json
+++ b/schemas/tlc/1.1/statuses/S0095.json
@@ -13,6 +13,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0096.json
+++ b/schemas/tlc/1.1/statuses/S0096.json
@@ -18,6 +18,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0097.json
+++ b/schemas/tlc/1.1/statuses/S0097.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0098.json
+++ b/schemas/tlc/1.1/statuses/S0098.json
@@ -15,6 +15,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0201.json
+++ b/schemas/tlc/1.1/statuses/S0201.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0202.json
+++ b/schemas/tlc/1.1/statuses/S0202.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0203.json
+++ b/schemas/tlc/1.1/statuses/S0203.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0204.json
+++ b/schemas/tlc/1.1/statuses/S0204.json
@@ -22,6 +22,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0205.json
+++ b/schemas/tlc/1.1/statuses/S0205.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0206.json
+++ b/schemas/tlc/1.1/statuses/S0206.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0207.json
+++ b/schemas/tlc/1.1/statuses/S0207.json
@@ -14,6 +14,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/schemas/tlc/1.1/statuses/S0208.json
+++ b/schemas/tlc/1.1/statuses/S0208.json
@@ -22,6 +22,21 @@
     {
       "if" : {
         "required" : [
+          "q"
+        ],
+        "properties" : {
+          "q" : {
+            "const" : "undefined"
+          }
+        }
+      },
+      "then" : {
+        "s" : null
+      }
+    },
+    {
+      "if" : {
+        "required" : [
           "n"
         ],
         "properties" : {

--- a/spec/core/status_response_spec.rb
+++ b/spec/core/status_response_spec.rb
@@ -21,25 +21,13 @@ RSpec.describe "Traffic Light Controller RSMP SXL Schema validation" do
      ]
   }}
 
-  it 'vals' do
-    attributes = {
-      "mType"=>"rSMsg",
-      "type"=>"StatusResponse",
-      "cId"=>"bad",
-      "sTs"=>"2023-07-11T10:46:20.360Z",
-      "sS"=>[{"sCI"=>"S0001", "n"=>"signalgroupstatus", "q"=>"undefined", "s"=>nil}],
-      "mId"=>"743bab9d-9c39-4ac6-b8fc-0f7113445674", "ntsOId"=>"KK+AG9998=001TC000", "xNId"=>""
-    }
-    schemas = {tlc: RSMP::Schema.latest_version(:tlc) }
-    expect( RSMP::Schema.validate(attributes, schemas) ).to be_nil
-  end
-
   it 'accepts valid message' do
     expect(validate message, 'core').to be_nil
   end
 
   it 'accepts valid message with q=undefined, s=null from 3.1.3' do
     expect(validate undefined, 'core', '>=3.1.3').to be_nil
+    expect(validate undefined, 'core', '<3.1.3').to eq( [["/sS/0/s", "string"]] )
   end
 
   it 'catches missing component id' do

--- a/spec/schemer_helper.rb
+++ b/spec/schemer_helper.rb
@@ -39,8 +39,8 @@ def validate_variations json_variations, schema, versions = :all
   if versions == :all
     version_list = $schemers[schema.to_s].keys
   elsif versions.is_a? String
-    # convert a string like '>=3.1.3' to an array off matching version strings,
-    # by using the Gem::Requirement tool.
+    # convert a string like '>=3.1.3' to an array of matching version strings,
+    # by using the Gem::Requirement class.
     # This this has nothing to do with gems, we just use the version matching helper.
     requirement = Gem::Requirement.new(versions)
     version_list = $schemers[schema.to_s].keys.select do |version|

--- a/spec/schemer_helper.rb
+++ b/spec/schemer_helper.rb
@@ -87,6 +87,7 @@ def validate_variations json_variations, schema, versions = :all
   errors.
     keys.
     group_by {|version| errors[version] }.
-    transform_values {|arr| arr.size == 1 ? arr.first : arr }. 
-    invert
+    transform_values {|arr| arr.size == 1 ? arr.first : arr }.
+    invert.
+    transform_values! {|arr| arr.uniq }
 end


### PR DESCRIPTION
allow s=null, q='undefined' in StatusReponse.

the sxl version allows this for all versions.
the core validation allows this for versions >=3.1.3 (when it was added to the spec)
 