### PR TITLE
S0006: Rename "stage" to "route"

### DIFF
--- a/schemas/tlc/1.1.1/sxl.yaml
+++ b/schemas/tlc/1.1.1/sxl.yaml
@@ -228,11 +228,11 @@ objects:
           status:
             type: boolean
             description: |-
-              False: Emergency stage inactive
-              True: Emergency stage active
+              False: Emergency route inactive
+              True: Emergency route active
           emergencystage:
             type: integer
-            description: Number of emergency stage (set to zero if no route is active)
+            description: Number of emergency route (set to zero if no route is active)
             min: 0
             max: 255
       S0007:


### PR DESCRIPTION
Rename "stage" to route" in description of S0006.

Discussed in https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/issues/110 and https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/issues/145