### PR TITLE
S0005: Add intersection to startup-mode

### DIFF
--- a/schemas/tlc/1.1.1/sxl.yaml
+++ b/schemas/tlc/1.1.1/sxl.yaml
@@ -218,6 +218,16 @@ objects:
             description: |-
               False: Controller is not in start up mode
               True: Controller is currently in start up mode
+          statusByIntersection:
+            description:
+            type: array
+            items:
+              intersection:
+                type: integer
+                description: Intersection
+              startup:
+                type: boolean
+                description: Intersection is currently in start up mode
       S0006:
         description: |-
           Emergency route.


### PR DESCRIPTION
As discussed in https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/issues/117, add ability to get the startup-mode for each intersection.