### PR TITLE
S0018: Mark as deprecated

### DIFF
--- a/schemas/tlc/1.1.1/sxl.yaml
+++ b/schemas/tlc/1.1.1/sxl.yaml
@@ -516,7 +516,8 @@ objects:
         arguments:
           number:
             type: integer
-            description: Number of time plans (depreciated)
+            deprecated: true
+            description: Number of time plans
             min: 1
             max: 65025
       S0019:


### PR DESCRIPTION
S0018: Mark as deprecated. It has been marked deprecated since earlier, but this uses the correct yaml formatting