### PR TITLE
Clarify m0001 regarding 'intersection'

### DIFF
--- a/schemas/tlc/1.2.1/sxl.yaml
+++ b/schemas/tlc/1.2.1/sxl.yaml
@@ -1108,7 +1108,10 @@ objects:
             max: 1440
           intersection:
             type: integer
-            description: Intersection number
+            description: |-
+              Intersection number.
+              Command only applies to specified intersection. Other intersections remains in their respective operating mode(s).
+              0: All intersections
             min: 0
             max: 255
         command: setValue


### PR DESCRIPTION
M0001:
- intersection=0, means all intersections
- only the specified intersection is affected by command

Original issue here: https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/issues/160