### PR TITLE
Unknown undefined

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rsmp_schema (0.8.6)
+    rsmp_schema (0.8.7)
       json_schemer (~> 2.3.0)
       thor (~> 1.3.1)
 

--- a/lib/rsmp_schema/convert/export/json_schema.rb
+++ b/lib/rsmp_schema/convert/export/json_schema.rb
@@ -153,11 +153,9 @@ module RSMP
                 "if" =>
                 {
                   "required" => ["q"],
-                  "properties" => { "q"=> { "const" => "undefined" }},
+                  "properties" => { "q"=> { "enum" => ["undefined","unknown"] }},
                 },
-                  "then" => {
-                  "s" => { "type" => "null" }
-                },
+                "then" => {},
                 "else" => {
                   "allOf" => item['arguments'].map do |key,argument|
                     {

--- a/lib/rsmp_schema/version.rb
+++ b/lib/rsmp_schema/version.rb
@@ -1,5 +1,5 @@
 module RSMP
   module Schema
-    VERSION = "0.8.6"
+    VERSION = "0.8.7"
   end
 end

--- a/schemas/tlc/1.0.10/alarms/A0008.json
+++ b/schemas/tlc/1.0.10/alarms/A0008.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/alarms/A0201.json
+++ b/schemas/tlc/1.0.10/alarms/A0201.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/alarms/A0202.json
+++ b/schemas/tlc/1.0.10/alarms/A0202.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/alarms/A0301.json
+++ b/schemas/tlc/1.0.10/alarms/A0301.json
@@ -20,14 +20,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/alarms/A0302.json
+++ b/schemas/tlc/1.0.10/alarms/A0302.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/commands/M0001.json
+++ b/schemas/tlc/1.0.10/commands/M0001.json
@@ -23,14 +23,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/commands/M0002.json
+++ b/schemas/tlc/1.0.10/commands/M0002.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/commands/M0003.json
+++ b/schemas/tlc/1.0.10/commands/M0003.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/commands/M0004.json
+++ b/schemas/tlc/1.0.10/commands/M0004.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/commands/M0005.json
+++ b/schemas/tlc/1.0.10/commands/M0005.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/commands/M0006.json
+++ b/schemas/tlc/1.0.10/commands/M0006.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/commands/M0007.json
+++ b/schemas/tlc/1.0.10/commands/M0007.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/commands/M0008.json
+++ b/schemas/tlc/1.0.10/commands/M0008.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/commands/M0010.json
+++ b/schemas/tlc/1.0.10/commands/M0010.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/commands/M0011.json
+++ b/schemas/tlc/1.0.10/commands/M0011.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/commands/M0012.json
+++ b/schemas/tlc/1.0.10/commands/M0012.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/commands/M0013.json
+++ b/schemas/tlc/1.0.10/commands/M0013.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/commands/M0019.json
+++ b/schemas/tlc/1.0.10/commands/M0019.json
@@ -23,14 +23,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/commands/M0103.json
+++ b/schemas/tlc/1.0.10/commands/M0103.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/commands/M0104.json
+++ b/schemas/tlc/1.0.10/commands/M0104.json
@@ -26,14 +26,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0001.json
+++ b/schemas/tlc/1.0.10/statuses/S0001.json
@@ -20,14 +20,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0002.json
+++ b/schemas/tlc/1.0.10/statuses/S0002.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0003.json
+++ b/schemas/tlc/1.0.10/statuses/S0003.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0004.json
+++ b/schemas/tlc/1.0.10/statuses/S0004.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0005.json
+++ b/schemas/tlc/1.0.10/statuses/S0005.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0006.json
+++ b/schemas/tlc/1.0.10/statuses/S0006.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0007.json
+++ b/schemas/tlc/1.0.10/statuses/S0007.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0008.json
+++ b/schemas/tlc/1.0.10/statuses/S0008.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0009.json
+++ b/schemas/tlc/1.0.10/statuses/S0009.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0010.json
+++ b/schemas/tlc/1.0.10/statuses/S0010.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0011.json
+++ b/schemas/tlc/1.0.10/statuses/S0011.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0012.json
+++ b/schemas/tlc/1.0.10/statuses/S0012.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0013.json
+++ b/schemas/tlc/1.0.10/statuses/S0013.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0014.json
+++ b/schemas/tlc/1.0.10/statuses/S0014.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0015.json
+++ b/schemas/tlc/1.0.10/statuses/S0015.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0016.json
+++ b/schemas/tlc/1.0.10/statuses/S0016.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0017.json
+++ b/schemas/tlc/1.0.10/statuses/S0017.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0018.json
+++ b/schemas/tlc/1.0.10/statuses/S0018.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0019.json
+++ b/schemas/tlc/1.0.10/statuses/S0019.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0020.json
+++ b/schemas/tlc/1.0.10/statuses/S0020.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0021.json
+++ b/schemas/tlc/1.0.10/statuses/S0021.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0091.json
+++ b/schemas/tlc/1.0.10/statuses/S0091.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0092.json
+++ b/schemas/tlc/1.0.10/statuses/S0092.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0095.json
+++ b/schemas/tlc/1.0.10/statuses/S0095.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0096.json
+++ b/schemas/tlc/1.0.10/statuses/S0096.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0201.json
+++ b/schemas/tlc/1.0.10/statuses/S0201.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0202.json
+++ b/schemas/tlc/1.0.10/statuses/S0202.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0203.json
+++ b/schemas/tlc/1.0.10/statuses/S0203.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.10/statuses/S0204.json
+++ b/schemas/tlc/1.0.10/statuses/S0204.json
@@ -26,14 +26,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/alarms/A0008.json
+++ b/schemas/tlc/1.0.13/alarms/A0008.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/alarms/A0201.json
+++ b/schemas/tlc/1.0.13/alarms/A0201.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/alarms/A0202.json
+++ b/schemas/tlc/1.0.13/alarms/A0202.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/alarms/A0301.json
+++ b/schemas/tlc/1.0.13/alarms/A0301.json
@@ -20,14 +20,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/alarms/A0302.json
+++ b/schemas/tlc/1.0.13/alarms/A0302.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/commands/M0001.json
+++ b/schemas/tlc/1.0.13/commands/M0001.json
@@ -23,14 +23,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/commands/M0002.json
+++ b/schemas/tlc/1.0.13/commands/M0002.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/commands/M0003.json
+++ b/schemas/tlc/1.0.13/commands/M0003.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/commands/M0004.json
+++ b/schemas/tlc/1.0.13/commands/M0004.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/commands/M0005.json
+++ b/schemas/tlc/1.0.13/commands/M0005.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/commands/M0006.json
+++ b/schemas/tlc/1.0.13/commands/M0006.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/commands/M0007.json
+++ b/schemas/tlc/1.0.13/commands/M0007.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/commands/M0008.json
+++ b/schemas/tlc/1.0.13/commands/M0008.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/commands/M0010.json
+++ b/schemas/tlc/1.0.13/commands/M0010.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/commands/M0011.json
+++ b/schemas/tlc/1.0.13/commands/M0011.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/commands/M0012.json
+++ b/schemas/tlc/1.0.13/commands/M0012.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/commands/M0013.json
+++ b/schemas/tlc/1.0.13/commands/M0013.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/commands/M0014.json
+++ b/schemas/tlc/1.0.13/commands/M0014.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/commands/M0015.json
+++ b/schemas/tlc/1.0.13/commands/M0015.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/commands/M0016.json
+++ b/schemas/tlc/1.0.13/commands/M0016.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/commands/M0017.json
+++ b/schemas/tlc/1.0.13/commands/M0017.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/commands/M0018.json
+++ b/schemas/tlc/1.0.13/commands/M0018.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/commands/M0019.json
+++ b/schemas/tlc/1.0.13/commands/M0019.json
@@ -23,14 +23,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/commands/M0103.json
+++ b/schemas/tlc/1.0.13/commands/M0103.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/commands/M0104.json
+++ b/schemas/tlc/1.0.13/commands/M0104.json
@@ -26,14 +26,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0001.json
+++ b/schemas/tlc/1.0.13/statuses/S0001.json
@@ -20,14 +20,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0002.json
+++ b/schemas/tlc/1.0.13/statuses/S0002.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0003.json
+++ b/schemas/tlc/1.0.13/statuses/S0003.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0004.json
+++ b/schemas/tlc/1.0.13/statuses/S0004.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0005.json
+++ b/schemas/tlc/1.0.13/statuses/S0005.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0006.json
+++ b/schemas/tlc/1.0.13/statuses/S0006.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0007.json
+++ b/schemas/tlc/1.0.13/statuses/S0007.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0008.json
+++ b/schemas/tlc/1.0.13/statuses/S0008.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0009.json
+++ b/schemas/tlc/1.0.13/statuses/S0009.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0010.json
+++ b/schemas/tlc/1.0.13/statuses/S0010.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0011.json
+++ b/schemas/tlc/1.0.13/statuses/S0011.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0012.json
+++ b/schemas/tlc/1.0.13/statuses/S0012.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0013.json
+++ b/schemas/tlc/1.0.13/statuses/S0013.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0014.json
+++ b/schemas/tlc/1.0.13/statuses/S0014.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0015.json
+++ b/schemas/tlc/1.0.13/statuses/S0015.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0016.json
+++ b/schemas/tlc/1.0.13/statuses/S0016.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0017.json
+++ b/schemas/tlc/1.0.13/statuses/S0017.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0018.json
+++ b/schemas/tlc/1.0.13/statuses/S0018.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0019.json
+++ b/schemas/tlc/1.0.13/statuses/S0019.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0020.json
+++ b/schemas/tlc/1.0.13/statuses/S0020.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0021.json
+++ b/schemas/tlc/1.0.13/statuses/S0021.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0022.json
+++ b/schemas/tlc/1.0.13/statuses/S0022.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0023.json
+++ b/schemas/tlc/1.0.13/statuses/S0023.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0024.json
+++ b/schemas/tlc/1.0.13/statuses/S0024.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0025.json
+++ b/schemas/tlc/1.0.13/statuses/S0025.json
@@ -24,14 +24,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0026.json
+++ b/schemas/tlc/1.0.13/statuses/S0026.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0027.json
+++ b/schemas/tlc/1.0.13/statuses/S0027.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0028.json
+++ b/schemas/tlc/1.0.13/statuses/S0028.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0029.json
+++ b/schemas/tlc/1.0.13/statuses/S0029.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0091.json
+++ b/schemas/tlc/1.0.13/statuses/S0091.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0092.json
+++ b/schemas/tlc/1.0.13/statuses/S0092.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0095.json
+++ b/schemas/tlc/1.0.13/statuses/S0095.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0096.json
+++ b/schemas/tlc/1.0.13/statuses/S0096.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0201.json
+++ b/schemas/tlc/1.0.13/statuses/S0201.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0202.json
+++ b/schemas/tlc/1.0.13/statuses/S0202.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0203.json
+++ b/schemas/tlc/1.0.13/statuses/S0203.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.13/statuses/S0204.json
+++ b/schemas/tlc/1.0.13/statuses/S0204.json
@@ -26,14 +26,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/alarms/A0008.json
+++ b/schemas/tlc/1.0.14/alarms/A0008.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/alarms/A0201.json
+++ b/schemas/tlc/1.0.14/alarms/A0201.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/alarms/A0202.json
+++ b/schemas/tlc/1.0.14/alarms/A0202.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/alarms/A0301.json
+++ b/schemas/tlc/1.0.14/alarms/A0301.json
@@ -20,14 +20,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/alarms/A0302.json
+++ b/schemas/tlc/1.0.14/alarms/A0302.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/commands/M0001.json
+++ b/schemas/tlc/1.0.14/commands/M0001.json
@@ -23,14 +23,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/commands/M0002.json
+++ b/schemas/tlc/1.0.14/commands/M0002.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/commands/M0003.json
+++ b/schemas/tlc/1.0.14/commands/M0003.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/commands/M0004.json
+++ b/schemas/tlc/1.0.14/commands/M0004.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/commands/M0005.json
+++ b/schemas/tlc/1.0.14/commands/M0005.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/commands/M0006.json
+++ b/schemas/tlc/1.0.14/commands/M0006.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/commands/M0007.json
+++ b/schemas/tlc/1.0.14/commands/M0007.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/commands/M0008.json
+++ b/schemas/tlc/1.0.14/commands/M0008.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/commands/M0010.json
+++ b/schemas/tlc/1.0.14/commands/M0010.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/commands/M0011.json
+++ b/schemas/tlc/1.0.14/commands/M0011.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/commands/M0012.json
+++ b/schemas/tlc/1.0.14/commands/M0012.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/commands/M0013.json
+++ b/schemas/tlc/1.0.14/commands/M0013.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/commands/M0014.json
+++ b/schemas/tlc/1.0.14/commands/M0014.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/commands/M0015.json
+++ b/schemas/tlc/1.0.14/commands/M0015.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/commands/M0016.json
+++ b/schemas/tlc/1.0.14/commands/M0016.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/commands/M0017.json
+++ b/schemas/tlc/1.0.14/commands/M0017.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/commands/M0018.json
+++ b/schemas/tlc/1.0.14/commands/M0018.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/commands/M0019.json
+++ b/schemas/tlc/1.0.14/commands/M0019.json
@@ -23,14 +23,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/commands/M0103.json
+++ b/schemas/tlc/1.0.14/commands/M0103.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/commands/M0104.json
+++ b/schemas/tlc/1.0.14/commands/M0104.json
@@ -26,14 +26,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0001.json
+++ b/schemas/tlc/1.0.14/statuses/S0001.json
@@ -20,14 +20,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0002.json
+++ b/schemas/tlc/1.0.14/statuses/S0002.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0003.json
+++ b/schemas/tlc/1.0.14/statuses/S0003.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0004.json
+++ b/schemas/tlc/1.0.14/statuses/S0004.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0005.json
+++ b/schemas/tlc/1.0.14/statuses/S0005.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0006.json
+++ b/schemas/tlc/1.0.14/statuses/S0006.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0007.json
+++ b/schemas/tlc/1.0.14/statuses/S0007.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0008.json
+++ b/schemas/tlc/1.0.14/statuses/S0008.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0009.json
+++ b/schemas/tlc/1.0.14/statuses/S0009.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0010.json
+++ b/schemas/tlc/1.0.14/statuses/S0010.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0011.json
+++ b/schemas/tlc/1.0.14/statuses/S0011.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0012.json
+++ b/schemas/tlc/1.0.14/statuses/S0012.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0013.json
+++ b/schemas/tlc/1.0.14/statuses/S0013.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0014.json
+++ b/schemas/tlc/1.0.14/statuses/S0014.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0015.json
+++ b/schemas/tlc/1.0.14/statuses/S0015.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0016.json
+++ b/schemas/tlc/1.0.14/statuses/S0016.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0017.json
+++ b/schemas/tlc/1.0.14/statuses/S0017.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0018.json
+++ b/schemas/tlc/1.0.14/statuses/S0018.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0019.json
+++ b/schemas/tlc/1.0.14/statuses/S0019.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0020.json
+++ b/schemas/tlc/1.0.14/statuses/S0020.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0021.json
+++ b/schemas/tlc/1.0.14/statuses/S0021.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0022.json
+++ b/schemas/tlc/1.0.14/statuses/S0022.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0023.json
+++ b/schemas/tlc/1.0.14/statuses/S0023.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0024.json
+++ b/schemas/tlc/1.0.14/statuses/S0024.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0025.json
+++ b/schemas/tlc/1.0.14/statuses/S0025.json
@@ -24,14 +24,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0026.json
+++ b/schemas/tlc/1.0.14/statuses/S0026.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0027.json
+++ b/schemas/tlc/1.0.14/statuses/S0027.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0028.json
+++ b/schemas/tlc/1.0.14/statuses/S0028.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0029.json
+++ b/schemas/tlc/1.0.14/statuses/S0029.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0091.json
+++ b/schemas/tlc/1.0.14/statuses/S0091.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0092.json
+++ b/schemas/tlc/1.0.14/statuses/S0092.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0095.json
+++ b/schemas/tlc/1.0.14/statuses/S0095.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0096.json
+++ b/schemas/tlc/1.0.14/statuses/S0096.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0201.json
+++ b/schemas/tlc/1.0.14/statuses/S0201.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0202.json
+++ b/schemas/tlc/1.0.14/statuses/S0202.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0203.json
+++ b/schemas/tlc/1.0.14/statuses/S0203.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0204.json
+++ b/schemas/tlc/1.0.14/statuses/S0204.json
@@ -26,14 +26,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0205.json
+++ b/schemas/tlc/1.0.14/statuses/S0205.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0206.json
+++ b/schemas/tlc/1.0.14/statuses/S0206.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0207.json
+++ b/schemas/tlc/1.0.14/statuses/S0207.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.14/statuses/S0208.json
+++ b/schemas/tlc/1.0.14/statuses/S0208.json
@@ -26,14 +26,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/alarms/A0008.json
+++ b/schemas/tlc/1.0.15/alarms/A0008.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/alarms/A0201.json
+++ b/schemas/tlc/1.0.15/alarms/A0201.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/alarms/A0202.json
+++ b/schemas/tlc/1.0.15/alarms/A0202.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/alarms/A0301.json
+++ b/schemas/tlc/1.0.15/alarms/A0301.json
@@ -20,14 +20,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/alarms/A0302.json
+++ b/schemas/tlc/1.0.15/alarms/A0302.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/commands/M0001.json
+++ b/schemas/tlc/1.0.15/commands/M0001.json
@@ -23,14 +23,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/commands/M0002.json
+++ b/schemas/tlc/1.0.15/commands/M0002.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/commands/M0003.json
+++ b/schemas/tlc/1.0.15/commands/M0003.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/commands/M0004.json
+++ b/schemas/tlc/1.0.15/commands/M0004.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/commands/M0005.json
+++ b/schemas/tlc/1.0.15/commands/M0005.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/commands/M0006.json
+++ b/schemas/tlc/1.0.15/commands/M0006.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/commands/M0007.json
+++ b/schemas/tlc/1.0.15/commands/M0007.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/commands/M0008.json
+++ b/schemas/tlc/1.0.15/commands/M0008.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/commands/M0010.json
+++ b/schemas/tlc/1.0.15/commands/M0010.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/commands/M0011.json
+++ b/schemas/tlc/1.0.15/commands/M0011.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/commands/M0012.json
+++ b/schemas/tlc/1.0.15/commands/M0012.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/commands/M0013.json
+++ b/schemas/tlc/1.0.15/commands/M0013.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/commands/M0014.json
+++ b/schemas/tlc/1.0.15/commands/M0014.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/commands/M0015.json
+++ b/schemas/tlc/1.0.15/commands/M0015.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/commands/M0016.json
+++ b/schemas/tlc/1.0.15/commands/M0016.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/commands/M0017.json
+++ b/schemas/tlc/1.0.15/commands/M0017.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/commands/M0018.json
+++ b/schemas/tlc/1.0.15/commands/M0018.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/commands/M0019.json
+++ b/schemas/tlc/1.0.15/commands/M0019.json
@@ -23,14 +23,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/commands/M0020.json
+++ b/schemas/tlc/1.0.15/commands/M0020.json
@@ -23,14 +23,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/commands/M0021.json
+++ b/schemas/tlc/1.0.15/commands/M0021.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/commands/M0103.json
+++ b/schemas/tlc/1.0.15/commands/M0103.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/commands/M0104.json
+++ b/schemas/tlc/1.0.15/commands/M0104.json
@@ -26,14 +26,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0001.json
+++ b/schemas/tlc/1.0.15/statuses/S0001.json
@@ -20,14 +20,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0002.json
+++ b/schemas/tlc/1.0.15/statuses/S0002.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0003.json
+++ b/schemas/tlc/1.0.15/statuses/S0003.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0004.json
+++ b/schemas/tlc/1.0.15/statuses/S0004.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0005.json
+++ b/schemas/tlc/1.0.15/statuses/S0005.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0006.json
+++ b/schemas/tlc/1.0.15/statuses/S0006.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0007.json
+++ b/schemas/tlc/1.0.15/statuses/S0007.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0008.json
+++ b/schemas/tlc/1.0.15/statuses/S0008.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0009.json
+++ b/schemas/tlc/1.0.15/statuses/S0009.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0010.json
+++ b/schemas/tlc/1.0.15/statuses/S0010.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0011.json
+++ b/schemas/tlc/1.0.15/statuses/S0011.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0012.json
+++ b/schemas/tlc/1.0.15/statuses/S0012.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0013.json
+++ b/schemas/tlc/1.0.15/statuses/S0013.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0014.json
+++ b/schemas/tlc/1.0.15/statuses/S0014.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0015.json
+++ b/schemas/tlc/1.0.15/statuses/S0015.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0016.json
+++ b/schemas/tlc/1.0.15/statuses/S0016.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0017.json
+++ b/schemas/tlc/1.0.15/statuses/S0017.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0018.json
+++ b/schemas/tlc/1.0.15/statuses/S0018.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0019.json
+++ b/schemas/tlc/1.0.15/statuses/S0019.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0020.json
+++ b/schemas/tlc/1.0.15/statuses/S0020.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0021.json
+++ b/schemas/tlc/1.0.15/statuses/S0021.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0022.json
+++ b/schemas/tlc/1.0.15/statuses/S0022.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0023.json
+++ b/schemas/tlc/1.0.15/statuses/S0023.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0024.json
+++ b/schemas/tlc/1.0.15/statuses/S0024.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0025.json
+++ b/schemas/tlc/1.0.15/statuses/S0025.json
@@ -24,14 +24,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0026.json
+++ b/schemas/tlc/1.0.15/statuses/S0026.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0027.json
+++ b/schemas/tlc/1.0.15/statuses/S0027.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0028.json
+++ b/schemas/tlc/1.0.15/statuses/S0028.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0029.json
+++ b/schemas/tlc/1.0.15/statuses/S0029.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0030.json
+++ b/schemas/tlc/1.0.15/statuses/S0030.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0031.json
+++ b/schemas/tlc/1.0.15/statuses/S0031.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0091.json
+++ b/schemas/tlc/1.0.15/statuses/S0091.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0092.json
+++ b/schemas/tlc/1.0.15/statuses/S0092.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0095.json
+++ b/schemas/tlc/1.0.15/statuses/S0095.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0096.json
+++ b/schemas/tlc/1.0.15/statuses/S0096.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0097.json
+++ b/schemas/tlc/1.0.15/statuses/S0097.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0098.json
+++ b/schemas/tlc/1.0.15/statuses/S0098.json
@@ -19,14 +19,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0201.json
+++ b/schemas/tlc/1.0.15/statuses/S0201.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0202.json
+++ b/schemas/tlc/1.0.15/statuses/S0202.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0203.json
+++ b/schemas/tlc/1.0.15/statuses/S0203.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0204.json
+++ b/schemas/tlc/1.0.15/statuses/S0204.json
@@ -26,14 +26,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0205.json
+++ b/schemas/tlc/1.0.15/statuses/S0205.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0206.json
+++ b/schemas/tlc/1.0.15/statuses/S0206.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0207.json
+++ b/schemas/tlc/1.0.15/statuses/S0207.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.15/statuses/S0208.json
+++ b/schemas/tlc/1.0.15/statuses/S0208.json
@@ -26,14 +26,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/alarms/A0008.json
+++ b/schemas/tlc/1.0.7/alarms/A0008.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/alarms/A0201.json
+++ b/schemas/tlc/1.0.7/alarms/A0201.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/alarms/A0202.json
+++ b/schemas/tlc/1.0.7/alarms/A0202.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/alarms/A0301.json
+++ b/schemas/tlc/1.0.7/alarms/A0301.json
@@ -20,14 +20,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/alarms/A0302.json
+++ b/schemas/tlc/1.0.7/alarms/A0302.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/commands/M0001.json
+++ b/schemas/tlc/1.0.7/commands/M0001.json
@@ -23,14 +23,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/commands/M0002.json
+++ b/schemas/tlc/1.0.7/commands/M0002.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/commands/M0003.json
+++ b/schemas/tlc/1.0.7/commands/M0003.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/commands/M0004.json
+++ b/schemas/tlc/1.0.7/commands/M0004.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/commands/M0005.json
+++ b/schemas/tlc/1.0.7/commands/M0005.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/commands/M0006.json
+++ b/schemas/tlc/1.0.7/commands/M0006.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/commands/M0007.json
+++ b/schemas/tlc/1.0.7/commands/M0007.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/commands/M0008.json
+++ b/schemas/tlc/1.0.7/commands/M0008.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/commands/M0010.json
+++ b/schemas/tlc/1.0.7/commands/M0010.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/commands/M0011.json
+++ b/schemas/tlc/1.0.7/commands/M0011.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/commands/M0019.json
+++ b/schemas/tlc/1.0.7/commands/M0019.json
@@ -23,14 +23,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/commands/M0103.json
+++ b/schemas/tlc/1.0.7/commands/M0103.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/commands/M0104.json
+++ b/schemas/tlc/1.0.7/commands/M0104.json
@@ -26,14 +26,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0001.json
+++ b/schemas/tlc/1.0.7/statuses/S0001.json
@@ -20,14 +20,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0002.json
+++ b/schemas/tlc/1.0.7/statuses/S0002.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0003.json
+++ b/schemas/tlc/1.0.7/statuses/S0003.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0004.json
+++ b/schemas/tlc/1.0.7/statuses/S0004.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0005.json
+++ b/schemas/tlc/1.0.7/statuses/S0005.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0006.json
+++ b/schemas/tlc/1.0.7/statuses/S0006.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0007.json
+++ b/schemas/tlc/1.0.7/statuses/S0007.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0008.json
+++ b/schemas/tlc/1.0.7/statuses/S0008.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0009.json
+++ b/schemas/tlc/1.0.7/statuses/S0009.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0010.json
+++ b/schemas/tlc/1.0.7/statuses/S0010.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0011.json
+++ b/schemas/tlc/1.0.7/statuses/S0011.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0012.json
+++ b/schemas/tlc/1.0.7/statuses/S0012.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0013.json
+++ b/schemas/tlc/1.0.7/statuses/S0013.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0014.json
+++ b/schemas/tlc/1.0.7/statuses/S0014.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0015.json
+++ b/schemas/tlc/1.0.7/statuses/S0015.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0016.json
+++ b/schemas/tlc/1.0.7/statuses/S0016.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0017.json
+++ b/schemas/tlc/1.0.7/statuses/S0017.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0018.json
+++ b/schemas/tlc/1.0.7/statuses/S0018.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0019.json
+++ b/schemas/tlc/1.0.7/statuses/S0019.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0020.json
+++ b/schemas/tlc/1.0.7/statuses/S0020.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0021.json
+++ b/schemas/tlc/1.0.7/statuses/S0021.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0025.json
+++ b/schemas/tlc/1.0.7/statuses/S0025.json
@@ -24,14 +24,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0091.json
+++ b/schemas/tlc/1.0.7/statuses/S0091.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0092.json
+++ b/schemas/tlc/1.0.7/statuses/S0092.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0095.json
+++ b/schemas/tlc/1.0.7/statuses/S0095.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0096.json
+++ b/schemas/tlc/1.0.7/statuses/S0096.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0201.json
+++ b/schemas/tlc/1.0.7/statuses/S0201.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0202.json
+++ b/schemas/tlc/1.0.7/statuses/S0202.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0203.json
+++ b/schemas/tlc/1.0.7/statuses/S0203.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.7/statuses/S0204.json
+++ b/schemas/tlc/1.0.7/statuses/S0204.json
@@ -26,14 +26,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/alarms/A0008.json
+++ b/schemas/tlc/1.0.8/alarms/A0008.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/alarms/A0201.json
+++ b/schemas/tlc/1.0.8/alarms/A0201.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/alarms/A0202.json
+++ b/schemas/tlc/1.0.8/alarms/A0202.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/alarms/A0301.json
+++ b/schemas/tlc/1.0.8/alarms/A0301.json
@@ -20,14 +20,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/alarms/A0302.json
+++ b/schemas/tlc/1.0.8/alarms/A0302.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/commands/M0001.json
+++ b/schemas/tlc/1.0.8/commands/M0001.json
@@ -23,14 +23,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/commands/M0002.json
+++ b/schemas/tlc/1.0.8/commands/M0002.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/commands/M0003.json
+++ b/schemas/tlc/1.0.8/commands/M0003.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/commands/M0004.json
+++ b/schemas/tlc/1.0.8/commands/M0004.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/commands/M0005.json
+++ b/schemas/tlc/1.0.8/commands/M0005.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/commands/M0006.json
+++ b/schemas/tlc/1.0.8/commands/M0006.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/commands/M0007.json
+++ b/schemas/tlc/1.0.8/commands/M0007.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/commands/M0008.json
+++ b/schemas/tlc/1.0.8/commands/M0008.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/commands/M0010.json
+++ b/schemas/tlc/1.0.8/commands/M0010.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/commands/M0011.json
+++ b/schemas/tlc/1.0.8/commands/M0011.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/commands/M0012.json
+++ b/schemas/tlc/1.0.8/commands/M0012.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/commands/M0013.json
+++ b/schemas/tlc/1.0.8/commands/M0013.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/commands/M0019.json
+++ b/schemas/tlc/1.0.8/commands/M0019.json
@@ -23,14 +23,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/commands/M0103.json
+++ b/schemas/tlc/1.0.8/commands/M0103.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/commands/M0104.json
+++ b/schemas/tlc/1.0.8/commands/M0104.json
@@ -26,14 +26,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0001.json
+++ b/schemas/tlc/1.0.8/statuses/S0001.json
@@ -20,14 +20,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0002.json
+++ b/schemas/tlc/1.0.8/statuses/S0002.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0003.json
+++ b/schemas/tlc/1.0.8/statuses/S0003.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0004.json
+++ b/schemas/tlc/1.0.8/statuses/S0004.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0005.json
+++ b/schemas/tlc/1.0.8/statuses/S0005.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0006.json
+++ b/schemas/tlc/1.0.8/statuses/S0006.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0007.json
+++ b/schemas/tlc/1.0.8/statuses/S0007.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0008.json
+++ b/schemas/tlc/1.0.8/statuses/S0008.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0009.json
+++ b/schemas/tlc/1.0.8/statuses/S0009.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0010.json
+++ b/schemas/tlc/1.0.8/statuses/S0010.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0011.json
+++ b/schemas/tlc/1.0.8/statuses/S0011.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0012.json
+++ b/schemas/tlc/1.0.8/statuses/S0012.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0013.json
+++ b/schemas/tlc/1.0.8/statuses/S0013.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0014.json
+++ b/schemas/tlc/1.0.8/statuses/S0014.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0015.json
+++ b/schemas/tlc/1.0.8/statuses/S0015.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0016.json
+++ b/schemas/tlc/1.0.8/statuses/S0016.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0017.json
+++ b/schemas/tlc/1.0.8/statuses/S0017.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0018.json
+++ b/schemas/tlc/1.0.8/statuses/S0018.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0019.json
+++ b/schemas/tlc/1.0.8/statuses/S0019.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0020.json
+++ b/schemas/tlc/1.0.8/statuses/S0020.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0021.json
+++ b/schemas/tlc/1.0.8/statuses/S0021.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0091.json
+++ b/schemas/tlc/1.0.8/statuses/S0091.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0092.json
+++ b/schemas/tlc/1.0.8/statuses/S0092.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0095.json
+++ b/schemas/tlc/1.0.8/statuses/S0095.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0096.json
+++ b/schemas/tlc/1.0.8/statuses/S0096.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0201.json
+++ b/schemas/tlc/1.0.8/statuses/S0201.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0202.json
+++ b/schemas/tlc/1.0.8/statuses/S0202.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0203.json
+++ b/schemas/tlc/1.0.8/statuses/S0203.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.8/statuses/S0204.json
+++ b/schemas/tlc/1.0.8/statuses/S0204.json
@@ -26,14 +26,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/alarms/A0008.json
+++ b/schemas/tlc/1.0.9/alarms/A0008.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/alarms/A0201.json
+++ b/schemas/tlc/1.0.9/alarms/A0201.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/alarms/A0202.json
+++ b/schemas/tlc/1.0.9/alarms/A0202.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/alarms/A0301.json
+++ b/schemas/tlc/1.0.9/alarms/A0301.json
@@ -20,14 +20,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/alarms/A0302.json
+++ b/schemas/tlc/1.0.9/alarms/A0302.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/commands/M0001.json
+++ b/schemas/tlc/1.0.9/commands/M0001.json
@@ -23,14 +23,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/commands/M0002.json
+++ b/schemas/tlc/1.0.9/commands/M0002.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/commands/M0003.json
+++ b/schemas/tlc/1.0.9/commands/M0003.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/commands/M0004.json
+++ b/schemas/tlc/1.0.9/commands/M0004.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/commands/M0005.json
+++ b/schemas/tlc/1.0.9/commands/M0005.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/commands/M0006.json
+++ b/schemas/tlc/1.0.9/commands/M0006.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/commands/M0007.json
+++ b/schemas/tlc/1.0.9/commands/M0007.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/commands/M0008.json
+++ b/schemas/tlc/1.0.9/commands/M0008.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/commands/M0010.json
+++ b/schemas/tlc/1.0.9/commands/M0010.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/commands/M0011.json
+++ b/schemas/tlc/1.0.9/commands/M0011.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/commands/M0012.json
+++ b/schemas/tlc/1.0.9/commands/M0012.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/commands/M0013.json
+++ b/schemas/tlc/1.0.9/commands/M0013.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/commands/M0019.json
+++ b/schemas/tlc/1.0.9/commands/M0019.json
@@ -23,14 +23,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/commands/M0103.json
+++ b/schemas/tlc/1.0.9/commands/M0103.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/commands/M0104.json
+++ b/schemas/tlc/1.0.9/commands/M0104.json
@@ -26,14 +26,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0001.json
+++ b/schemas/tlc/1.0.9/statuses/S0001.json
@@ -20,14 +20,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0002.json
+++ b/schemas/tlc/1.0.9/statuses/S0002.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0003.json
+++ b/schemas/tlc/1.0.9/statuses/S0003.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0004.json
+++ b/schemas/tlc/1.0.9/statuses/S0004.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0005.json
+++ b/schemas/tlc/1.0.9/statuses/S0005.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0006.json
+++ b/schemas/tlc/1.0.9/statuses/S0006.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0007.json
+++ b/schemas/tlc/1.0.9/statuses/S0007.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0008.json
+++ b/schemas/tlc/1.0.9/statuses/S0008.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0009.json
+++ b/schemas/tlc/1.0.9/statuses/S0009.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0010.json
+++ b/schemas/tlc/1.0.9/statuses/S0010.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0011.json
+++ b/schemas/tlc/1.0.9/statuses/S0011.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0012.json
+++ b/schemas/tlc/1.0.9/statuses/S0012.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0013.json
+++ b/schemas/tlc/1.0.9/statuses/S0013.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0014.json
+++ b/schemas/tlc/1.0.9/statuses/S0014.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0015.json
+++ b/schemas/tlc/1.0.9/statuses/S0015.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0016.json
+++ b/schemas/tlc/1.0.9/statuses/S0016.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0017.json
+++ b/schemas/tlc/1.0.9/statuses/S0017.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0018.json
+++ b/schemas/tlc/1.0.9/statuses/S0018.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0019.json
+++ b/schemas/tlc/1.0.9/statuses/S0019.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0020.json
+++ b/schemas/tlc/1.0.9/statuses/S0020.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0021.json
+++ b/schemas/tlc/1.0.9/statuses/S0021.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0091.json
+++ b/schemas/tlc/1.0.9/statuses/S0091.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0092.json
+++ b/schemas/tlc/1.0.9/statuses/S0092.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0095.json
+++ b/schemas/tlc/1.0.9/statuses/S0095.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0096.json
+++ b/schemas/tlc/1.0.9/statuses/S0096.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0201.json
+++ b/schemas/tlc/1.0.9/statuses/S0201.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0202.json
+++ b/schemas/tlc/1.0.9/statuses/S0202.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0203.json
+++ b/schemas/tlc/1.0.9/statuses/S0203.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.0.9/statuses/S0204.json
+++ b/schemas/tlc/1.0.9/statuses/S0204.json
@@ -26,14 +26,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/alarms/A0007.json
+++ b/schemas/tlc/1.1.0/alarms/A0007.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/alarms/A0008.json
+++ b/schemas/tlc/1.1.0/alarms/A0008.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/alarms/A0201.json
+++ b/schemas/tlc/1.1.0/alarms/A0201.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/alarms/A0202.json
+++ b/schemas/tlc/1.1.0/alarms/A0202.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/alarms/A0301.json
+++ b/schemas/tlc/1.1.0/alarms/A0301.json
@@ -20,14 +20,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/alarms/A0302.json
+++ b/schemas/tlc/1.1.0/alarms/A0302.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/alarms/A0303.json
+++ b/schemas/tlc/1.1.0/alarms/A0303.json
@@ -20,14 +20,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/alarms/A0304.json
+++ b/schemas/tlc/1.1.0/alarms/A0304.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/commands/M0001.json
+++ b/schemas/tlc/1.1.0/commands/M0001.json
@@ -23,14 +23,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/commands/M0002.json
+++ b/schemas/tlc/1.1.0/commands/M0002.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/commands/M0003.json
+++ b/schemas/tlc/1.1.0/commands/M0003.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/commands/M0004.json
+++ b/schemas/tlc/1.1.0/commands/M0004.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/commands/M0005.json
+++ b/schemas/tlc/1.1.0/commands/M0005.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/commands/M0006.json
+++ b/schemas/tlc/1.1.0/commands/M0006.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/commands/M0007.json
+++ b/schemas/tlc/1.1.0/commands/M0007.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/commands/M0008.json
+++ b/schemas/tlc/1.1.0/commands/M0008.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/commands/M0010.json
+++ b/schemas/tlc/1.1.0/commands/M0010.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/commands/M0011.json
+++ b/schemas/tlc/1.1.0/commands/M0011.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/commands/M0012.json
+++ b/schemas/tlc/1.1.0/commands/M0012.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/commands/M0013.json
+++ b/schemas/tlc/1.1.0/commands/M0013.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/commands/M0014.json
+++ b/schemas/tlc/1.1.0/commands/M0014.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/commands/M0015.json
+++ b/schemas/tlc/1.1.0/commands/M0015.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/commands/M0016.json
+++ b/schemas/tlc/1.1.0/commands/M0016.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/commands/M0017.json
+++ b/schemas/tlc/1.1.0/commands/M0017.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/commands/M0018.json
+++ b/schemas/tlc/1.1.0/commands/M0018.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/commands/M0019.json
+++ b/schemas/tlc/1.1.0/commands/M0019.json
@@ -23,14 +23,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/commands/M0020.json
+++ b/schemas/tlc/1.1.0/commands/M0020.json
@@ -23,14 +23,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/commands/M0021.json
+++ b/schemas/tlc/1.1.0/commands/M0021.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/commands/M0022.json
+++ b/schemas/tlc/1.1.0/commands/M0022.json
@@ -31,14 +31,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/commands/M0023.json
+++ b/schemas/tlc/1.1.0/commands/M0023.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/commands/M0103.json
+++ b/schemas/tlc/1.1.0/commands/M0103.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/commands/M0104.json
+++ b/schemas/tlc/1.1.0/commands/M0104.json
@@ -26,14 +26,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0001.json
+++ b/schemas/tlc/1.1.0/statuses/S0001.json
@@ -20,14 +20,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0002.json
+++ b/schemas/tlc/1.1.0/statuses/S0002.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0003.json
+++ b/schemas/tlc/1.1.0/statuses/S0003.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0004.json
+++ b/schemas/tlc/1.1.0/statuses/S0004.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0005.json
+++ b/schemas/tlc/1.1.0/statuses/S0005.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0006.json
+++ b/schemas/tlc/1.1.0/statuses/S0006.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0007.json
+++ b/schemas/tlc/1.1.0/statuses/S0007.json
@@ -19,14 +19,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0008.json
+++ b/schemas/tlc/1.1.0/statuses/S0008.json
@@ -19,14 +19,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0009.json
+++ b/schemas/tlc/1.1.0/statuses/S0009.json
@@ -19,14 +19,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0010.json
+++ b/schemas/tlc/1.1.0/statuses/S0010.json
@@ -19,14 +19,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0011.json
+++ b/schemas/tlc/1.1.0/statuses/S0011.json
@@ -19,14 +19,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0012.json
+++ b/schemas/tlc/1.1.0/statuses/S0012.json
@@ -19,14 +19,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0013.json
+++ b/schemas/tlc/1.1.0/statuses/S0013.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0014.json
+++ b/schemas/tlc/1.1.0/statuses/S0014.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0015.json
+++ b/schemas/tlc/1.1.0/statuses/S0015.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0016.json
+++ b/schemas/tlc/1.1.0/statuses/S0016.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0017.json
+++ b/schemas/tlc/1.1.0/statuses/S0017.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0018.json
+++ b/schemas/tlc/1.1.0/statuses/S0018.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0019.json
+++ b/schemas/tlc/1.1.0/statuses/S0019.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0020.json
+++ b/schemas/tlc/1.1.0/statuses/S0020.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0021.json
+++ b/schemas/tlc/1.1.0/statuses/S0021.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0022.json
+++ b/schemas/tlc/1.1.0/statuses/S0022.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0023.json
+++ b/schemas/tlc/1.1.0/statuses/S0023.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0024.json
+++ b/schemas/tlc/1.1.0/statuses/S0024.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0025.json
+++ b/schemas/tlc/1.1.0/statuses/S0025.json
@@ -24,14 +24,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0026.json
+++ b/schemas/tlc/1.1.0/statuses/S0026.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0027.json
+++ b/schemas/tlc/1.1.0/statuses/S0027.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0028.json
+++ b/schemas/tlc/1.1.0/statuses/S0028.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0029.json
+++ b/schemas/tlc/1.1.0/statuses/S0029.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0030.json
+++ b/schemas/tlc/1.1.0/statuses/S0030.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0031.json
+++ b/schemas/tlc/1.1.0/statuses/S0031.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0032.json
+++ b/schemas/tlc/1.1.0/statuses/S0032.json
@@ -19,14 +19,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0033.json
+++ b/schemas/tlc/1.1.0/statuses/S0033.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0034.json
+++ b/schemas/tlc/1.1.0/statuses/S0034.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0091.json
+++ b/schemas/tlc/1.1.0/statuses/S0091.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0092.json
+++ b/schemas/tlc/1.1.0/statuses/S0092.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0095.json
+++ b/schemas/tlc/1.1.0/statuses/S0095.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0096.json
+++ b/schemas/tlc/1.1.0/statuses/S0096.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0097.json
+++ b/schemas/tlc/1.1.0/statuses/S0097.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0098.json
+++ b/schemas/tlc/1.1.0/statuses/S0098.json
@@ -19,14 +19,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0201.json
+++ b/schemas/tlc/1.1.0/statuses/S0201.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0202.json
+++ b/schemas/tlc/1.1.0/statuses/S0202.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0203.json
+++ b/schemas/tlc/1.1.0/statuses/S0203.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0204.json
+++ b/schemas/tlc/1.1.0/statuses/S0204.json
@@ -26,14 +26,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0205.json
+++ b/schemas/tlc/1.1.0/statuses/S0205.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0206.json
+++ b/schemas/tlc/1.1.0/statuses/S0206.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0207.json
+++ b/schemas/tlc/1.1.0/statuses/S0207.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.1.0/statuses/S0208.json
+++ b/schemas/tlc/1.1.0/statuses/S0208.json
@@ -26,14 +26,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/alarms/A0007.json
+++ b/schemas/tlc/1.2.0/alarms/A0007.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/alarms/A0008.json
+++ b/schemas/tlc/1.2.0/alarms/A0008.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/alarms/A0201.json
+++ b/schemas/tlc/1.2.0/alarms/A0201.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/alarms/A0202.json
+++ b/schemas/tlc/1.2.0/alarms/A0202.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/alarms/A0301.json
+++ b/schemas/tlc/1.2.0/alarms/A0301.json
@@ -20,14 +20,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/alarms/A0302.json
+++ b/schemas/tlc/1.2.0/alarms/A0302.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/alarms/A0303.json
+++ b/schemas/tlc/1.2.0/alarms/A0303.json
@@ -20,14 +20,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/alarms/A0304.json
+++ b/schemas/tlc/1.2.0/alarms/A0304.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/commands/M0001.json
+++ b/schemas/tlc/1.2.0/commands/M0001.json
@@ -23,14 +23,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/commands/M0002.json
+++ b/schemas/tlc/1.2.0/commands/M0002.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/commands/M0003.json
+++ b/schemas/tlc/1.2.0/commands/M0003.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/commands/M0004.json
+++ b/schemas/tlc/1.2.0/commands/M0004.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/commands/M0005.json
+++ b/schemas/tlc/1.2.0/commands/M0005.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/commands/M0006.json
+++ b/schemas/tlc/1.2.0/commands/M0006.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/commands/M0007.json
+++ b/schemas/tlc/1.2.0/commands/M0007.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/commands/M0008.json
+++ b/schemas/tlc/1.2.0/commands/M0008.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/commands/M0010.json
+++ b/schemas/tlc/1.2.0/commands/M0010.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/commands/M0011.json
+++ b/schemas/tlc/1.2.0/commands/M0011.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/commands/M0012.json
+++ b/schemas/tlc/1.2.0/commands/M0012.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/commands/M0013.json
+++ b/schemas/tlc/1.2.0/commands/M0013.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/commands/M0014.json
+++ b/schemas/tlc/1.2.0/commands/M0014.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/commands/M0015.json
+++ b/schemas/tlc/1.2.0/commands/M0015.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/commands/M0016.json
+++ b/schemas/tlc/1.2.0/commands/M0016.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/commands/M0017.json
+++ b/schemas/tlc/1.2.0/commands/M0017.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/commands/M0018.json
+++ b/schemas/tlc/1.2.0/commands/M0018.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/commands/M0019.json
+++ b/schemas/tlc/1.2.0/commands/M0019.json
@@ -23,14 +23,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/commands/M0020.json
+++ b/schemas/tlc/1.2.0/commands/M0020.json
@@ -23,14 +23,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/commands/M0021.json
+++ b/schemas/tlc/1.2.0/commands/M0021.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/commands/M0022.json
+++ b/schemas/tlc/1.2.0/commands/M0022.json
@@ -31,14 +31,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/commands/M0023.json
+++ b/schemas/tlc/1.2.0/commands/M0023.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/commands/M0103.json
+++ b/schemas/tlc/1.2.0/commands/M0103.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/commands/M0104.json
+++ b/schemas/tlc/1.2.0/commands/M0104.json
@@ -26,14 +26,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0001.json
+++ b/schemas/tlc/1.2.0/statuses/S0001.json
@@ -20,14 +20,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0002.json
+++ b/schemas/tlc/1.2.0/statuses/S0002.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0003.json
+++ b/schemas/tlc/1.2.0/statuses/S0003.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0004.json
+++ b/schemas/tlc/1.2.0/statuses/S0004.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0005.json
+++ b/schemas/tlc/1.2.0/statuses/S0005.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0006.json
+++ b/schemas/tlc/1.2.0/statuses/S0006.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0007.json
+++ b/schemas/tlc/1.2.0/statuses/S0007.json
@@ -19,14 +19,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0008.json
+++ b/schemas/tlc/1.2.0/statuses/S0008.json
@@ -19,14 +19,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0009.json
+++ b/schemas/tlc/1.2.0/statuses/S0009.json
@@ -19,14 +19,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0010.json
+++ b/schemas/tlc/1.2.0/statuses/S0010.json
@@ -19,14 +19,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0011.json
+++ b/schemas/tlc/1.2.0/statuses/S0011.json
@@ -19,14 +19,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0012.json
+++ b/schemas/tlc/1.2.0/statuses/S0012.json
@@ -19,14 +19,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0013.json
+++ b/schemas/tlc/1.2.0/statuses/S0013.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0014.json
+++ b/schemas/tlc/1.2.0/statuses/S0014.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0015.json
+++ b/schemas/tlc/1.2.0/statuses/S0015.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0016.json
+++ b/schemas/tlc/1.2.0/statuses/S0016.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0017.json
+++ b/schemas/tlc/1.2.0/statuses/S0017.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0019.json
+++ b/schemas/tlc/1.2.0/statuses/S0019.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0020.json
+++ b/schemas/tlc/1.2.0/statuses/S0020.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0021.json
+++ b/schemas/tlc/1.2.0/statuses/S0021.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0022.json
+++ b/schemas/tlc/1.2.0/statuses/S0022.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0023.json
+++ b/schemas/tlc/1.2.0/statuses/S0023.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0024.json
+++ b/schemas/tlc/1.2.0/statuses/S0024.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0025.json
+++ b/schemas/tlc/1.2.0/statuses/S0025.json
@@ -24,14 +24,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0026.json
+++ b/schemas/tlc/1.2.0/statuses/S0026.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0027.json
+++ b/schemas/tlc/1.2.0/statuses/S0027.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0028.json
+++ b/schemas/tlc/1.2.0/statuses/S0028.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0029.json
+++ b/schemas/tlc/1.2.0/statuses/S0029.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0030.json
+++ b/schemas/tlc/1.2.0/statuses/S0030.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0031.json
+++ b/schemas/tlc/1.2.0/statuses/S0031.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0032.json
+++ b/schemas/tlc/1.2.0/statuses/S0032.json
@@ -19,14 +19,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0033.json
+++ b/schemas/tlc/1.2.0/statuses/S0033.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0034.json
+++ b/schemas/tlc/1.2.0/statuses/S0034.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0035.json
+++ b/schemas/tlc/1.2.0/statuses/S0035.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0091.json
+++ b/schemas/tlc/1.2.0/statuses/S0091.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0092.json
+++ b/schemas/tlc/1.2.0/statuses/S0092.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0095.json
+++ b/schemas/tlc/1.2.0/statuses/S0095.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0096.json
+++ b/schemas/tlc/1.2.0/statuses/S0096.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0097.json
+++ b/schemas/tlc/1.2.0/statuses/S0097.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0098.json
+++ b/schemas/tlc/1.2.0/statuses/S0098.json
@@ -19,14 +19,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0201.json
+++ b/schemas/tlc/1.2.0/statuses/S0201.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0202.json
+++ b/schemas/tlc/1.2.0/statuses/S0202.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0203.json
+++ b/schemas/tlc/1.2.0/statuses/S0203.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0204.json
+++ b/schemas/tlc/1.2.0/statuses/S0204.json
@@ -26,14 +26,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0205.json
+++ b/schemas/tlc/1.2.0/statuses/S0205.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0206.json
+++ b/schemas/tlc/1.2.0/statuses/S0206.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0207.json
+++ b/schemas/tlc/1.2.0/statuses/S0207.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.0/statuses/S0208.json
+++ b/schemas/tlc/1.2.0/statuses/S0208.json
@@ -26,14 +26,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/alarms/A0007.json
+++ b/schemas/tlc/1.2.1/alarms/A0007.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/alarms/A0008.json
+++ b/schemas/tlc/1.2.1/alarms/A0008.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/alarms/A0201.json
+++ b/schemas/tlc/1.2.1/alarms/A0201.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/alarms/A0202.json
+++ b/schemas/tlc/1.2.1/alarms/A0202.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/alarms/A0301.json
+++ b/schemas/tlc/1.2.1/alarms/A0301.json
@@ -20,14 +20,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/alarms/A0302.json
+++ b/schemas/tlc/1.2.1/alarms/A0302.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/alarms/A0303.json
+++ b/schemas/tlc/1.2.1/alarms/A0303.json
@@ -20,14 +20,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/alarms/A0304.json
+++ b/schemas/tlc/1.2.1/alarms/A0304.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/commands/M0001.json
+++ b/schemas/tlc/1.2.1/commands/M0001.json
@@ -23,14 +23,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/commands/M0002.json
+++ b/schemas/tlc/1.2.1/commands/M0002.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/commands/M0003.json
+++ b/schemas/tlc/1.2.1/commands/M0003.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/commands/M0004.json
+++ b/schemas/tlc/1.2.1/commands/M0004.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/commands/M0005.json
+++ b/schemas/tlc/1.2.1/commands/M0005.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/commands/M0006.json
+++ b/schemas/tlc/1.2.1/commands/M0006.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/commands/M0007.json
+++ b/schemas/tlc/1.2.1/commands/M0007.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/commands/M0008.json
+++ b/schemas/tlc/1.2.1/commands/M0008.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/commands/M0010.json
+++ b/schemas/tlc/1.2.1/commands/M0010.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/commands/M0011.json
+++ b/schemas/tlc/1.2.1/commands/M0011.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/commands/M0012.json
+++ b/schemas/tlc/1.2.1/commands/M0012.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/commands/M0013.json
+++ b/schemas/tlc/1.2.1/commands/M0013.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/commands/M0014.json
+++ b/schemas/tlc/1.2.1/commands/M0014.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/commands/M0015.json
+++ b/schemas/tlc/1.2.1/commands/M0015.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/commands/M0016.json
+++ b/schemas/tlc/1.2.1/commands/M0016.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/commands/M0017.json
+++ b/schemas/tlc/1.2.1/commands/M0017.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/commands/M0018.json
+++ b/schemas/tlc/1.2.1/commands/M0018.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/commands/M0019.json
+++ b/schemas/tlc/1.2.1/commands/M0019.json
@@ -23,14 +23,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/commands/M0020.json
+++ b/schemas/tlc/1.2.1/commands/M0020.json
@@ -23,14 +23,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/commands/M0021.json
+++ b/schemas/tlc/1.2.1/commands/M0021.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/commands/M0022.json
+++ b/schemas/tlc/1.2.1/commands/M0022.json
@@ -31,14 +31,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/commands/M0023.json
+++ b/schemas/tlc/1.2.1/commands/M0023.json
@@ -21,14 +21,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/commands/M0103.json
+++ b/schemas/tlc/1.2.1/commands/M0103.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/commands/M0104.json
+++ b/schemas/tlc/1.2.1/commands/M0104.json
@@ -26,14 +26,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0001.json
+++ b/schemas/tlc/1.2.1/statuses/S0001.json
@@ -20,14 +20,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0002.json
+++ b/schemas/tlc/1.2.1/statuses/S0002.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0003.json
+++ b/schemas/tlc/1.2.1/statuses/S0003.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0004.json
+++ b/schemas/tlc/1.2.1/statuses/S0004.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0005.json
+++ b/schemas/tlc/1.2.1/statuses/S0005.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0006.json
+++ b/schemas/tlc/1.2.1/statuses/S0006.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0007.json
+++ b/schemas/tlc/1.2.1/statuses/S0007.json
@@ -19,14 +19,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0008.json
+++ b/schemas/tlc/1.2.1/statuses/S0008.json
@@ -19,14 +19,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0009.json
+++ b/schemas/tlc/1.2.1/statuses/S0009.json
@@ -19,14 +19,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0010.json
+++ b/schemas/tlc/1.2.1/statuses/S0010.json
@@ -19,14 +19,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0011.json
+++ b/schemas/tlc/1.2.1/statuses/S0011.json
@@ -19,14 +19,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0012.json
+++ b/schemas/tlc/1.2.1/statuses/S0012.json
@@ -19,14 +19,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0013.json
+++ b/schemas/tlc/1.2.1/statuses/S0013.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0014.json
+++ b/schemas/tlc/1.2.1/statuses/S0014.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0015.json
+++ b/schemas/tlc/1.2.1/statuses/S0015.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0016.json
+++ b/schemas/tlc/1.2.1/statuses/S0016.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0017.json
+++ b/schemas/tlc/1.2.1/statuses/S0017.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0019.json
+++ b/schemas/tlc/1.2.1/statuses/S0019.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0020.json
+++ b/schemas/tlc/1.2.1/statuses/S0020.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0021.json
+++ b/schemas/tlc/1.2.1/statuses/S0021.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0022.json
+++ b/schemas/tlc/1.2.1/statuses/S0022.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0023.json
+++ b/schemas/tlc/1.2.1/statuses/S0023.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0024.json
+++ b/schemas/tlc/1.2.1/statuses/S0024.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0025.json
+++ b/schemas/tlc/1.2.1/statuses/S0025.json
@@ -24,14 +24,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0026.json
+++ b/schemas/tlc/1.2.1/statuses/S0026.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0027.json
+++ b/schemas/tlc/1.2.1/statuses/S0027.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0028.json
+++ b/schemas/tlc/1.2.1/statuses/S0028.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0029.json
+++ b/schemas/tlc/1.2.1/statuses/S0029.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0030.json
+++ b/schemas/tlc/1.2.1/statuses/S0030.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0031.json
+++ b/schemas/tlc/1.2.1/statuses/S0031.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0032.json
+++ b/schemas/tlc/1.2.1/statuses/S0032.json
@@ -19,14 +19,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0033.json
+++ b/schemas/tlc/1.2.1/statuses/S0033.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0034.json
+++ b/schemas/tlc/1.2.1/statuses/S0034.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0035.json
+++ b/schemas/tlc/1.2.1/statuses/S0035.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0091.json
+++ b/schemas/tlc/1.2.1/statuses/S0091.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0092.json
+++ b/schemas/tlc/1.2.1/statuses/S0092.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0095.json
+++ b/schemas/tlc/1.2.1/statuses/S0095.json
@@ -17,14 +17,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0096.json
+++ b/schemas/tlc/1.2.1/statuses/S0096.json
@@ -22,14 +22,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0097.json
+++ b/schemas/tlc/1.2.1/statuses/S0097.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0098.json
+++ b/schemas/tlc/1.2.1/statuses/S0098.json
@@ -19,14 +19,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0201.json
+++ b/schemas/tlc/1.2.1/statuses/S0201.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0202.json
+++ b/schemas/tlc/1.2.1/statuses/S0202.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0203.json
+++ b/schemas/tlc/1.2.1/statuses/S0203.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0204.json
+++ b/schemas/tlc/1.2.1/statuses/S0204.json
@@ -26,14 +26,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0205.json
+++ b/schemas/tlc/1.2.1/statuses/S0205.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0206.json
+++ b/schemas/tlc/1.2.1/statuses/S0206.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0207.json
+++ b/schemas/tlc/1.2.1/statuses/S0207.json
@@ -18,14 +18,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/schemas/tlc/1.2.1/statuses/S0208.json
+++ b/schemas/tlc/1.2.1/statuses/S0208.json
@@ -26,14 +26,14 @@
         ],
         "properties" : {
           "q" : {
-            "const" : "undefined"
+            "enum" : [
+              "undefined",
+              "unknown"
+            ]
           }
         }
       },
       "then" : {
-        "s" : {
-          "type" : "null"
-        }
       },
       "else" : {
         "allOf" : [

--- a/spec/tlc/status_update_spec.rb
+++ b/spec/tlc/status_update_spec.rb
@@ -2,7 +2,7 @@ RSpec.describe "Traffic Light Controller RSMP SXL Schema validation" do
   let(:message) {{
     "mType" => "rSMsg",
     "mId" => "4173c2c8-a933-43cb-9425-66d4613731ed",
-    "type" => "StatusResponse",
+    "type" => "StatusUpdate",
     "cId" => "O+14439=481WA001",
     "sTs" => "2015-06-08T09:15:18.266Z",
      "sS" => [


### PR DESCRIPTION
The sxl schemas includes a check that s must be null if q is undefined. This was removed because:
- it's already checked in the core spec
- the case where q=unknown was missing


Added tlc schema tests for status updates.