### PR TITLE
Use legacy types

### DIFF
--- a/schemas/tlc/1.3.0/sxl.yaml
+++ b/schemas/tlc/1.3.0/sxl.yaml
@@ -118,7 +118,7 @@ objects:
               - : Signal group is undefined/does not exist
             pattern: "^[a-hA-G0-9N-P]*$"
           cyclecounter:
-            type: integer
+            type: integer_as_string
             description: |-
               Cycle counter.
               Used for handling of coordination between TLC’s.
@@ -136,7 +136,7 @@ objects:
             min: 0
             max: 999
           basecyclecounter:
-            type: integer
+            type: integer_as_string
             description: |-
               Base cycle counter.
               Used for handling of coordination between TLC’s.
@@ -145,7 +145,7 @@ objects:
             min: 0
             max: 999
           stage:
-            type: integer
+            type: integer_as_string
             description: Current stage (isolated)
             min: 0
             max: 999
@@ -156,7 +156,7 @@ objects:
           Can be used to draw a live signal group diagram as well provide diagnostic information about the performance of the controller. Can also be used for bus priority, external control systems, and much more.
         arguments:
           detectorlogicstatus:
-            type: string
+            type: string_list_as_string
             description: |-
               Detector logic status as text field.
               Each character represent the state of the detector logic in consecutive order,
@@ -171,7 +171,7 @@ objects:
           Input is used where the traffic light controller must react to external control. It could be external detectors, bus priority, and much more.
         arguments:
           inputstatus:
-            type: string
+            type: string_list_as_string
             description: |-
               Input status as text field.
               Each character represent the state of the input in consecutive order,
@@ -201,7 +201,7 @@ objects:
           During startup mode the traffic controller shows dark, red, yellow flash or using the predetermined start cycle (minimum times).
         arguments:
           status:
-            type: boolean
+            type: boolean_as_string
             description: |-
               False: Controller is not in start up mode
               True: Controller is currently in start up mode
@@ -212,12 +212,12 @@ objects:
             type: array
             items:
               intersection:
-                type: integer
+                type: integer_as_string
                 description: Intersection id
                 min: 0
                 max: 255
               startup:
-                type: boolean
+                type: boolean_as_string
                 description: Start up mode
       S0006:
         description: |-
@@ -231,13 +231,13 @@ objects:
           Deprecated, use S0035 instead.
         arguments:
           status:
-            type: boolean
+            type: boolean_as_string
             deprecated: true
             description: |-
               False: Emergency route inactive
               True: Emergency route active
           emergencystage:
-            type: integer
+            type: integer_as_string
             deprecated: true
             description: Number of emergency route (set to zero if no route is active)
             min: 0
@@ -251,20 +251,20 @@ objects:
           Please note that all values in this status uses comma-separated lists - one value for each intersection, e.g. "0" and "True" (one intersection) or "1,2" and "True,False" (two intersections).
         arguments:
           intersection:
-            type: integer_list
+            type: integer_as_string_list
             description: |-
               Comma separated list of intersections which the status relates to, e.g. “1,2”.
               Use “0” for all intersections of the TLC.
             min: 0
             max: 255
           status:
-            type: boolean_list
+            type: boolean_as_string_list
             description: |-
               False: Traffic Light Controller in dark mode
               True: Traffic Light Controller not in dark mode
           source:
             description: Source of the status change
-            type: string_list
+            type: string_list_as_string_list
             values:
               operator_panel: Operator panel
               calendar_clock: Calendar/clock
@@ -280,19 +280,19 @@ objects:
           Please note that all values in this status uses comma-separated lists - one value for each intersection, e.g. "0" and "True" (one intersection) or "1,2" and "True,False" (two intersections).
         arguments:
           intersection:
-            type: integer_list
+            type: integer_as_string_list
             description: |-
               Comma separated list of intersections which the status relates to, e.g. “1,2”.
               Use “0” for all intersections of the TLC.
             min: 0
             max: 255
           status:
-            type: boolean_list
+            type: boolean_as_string_list
             description: |-
               False: Manual control inactive
               True: Manual control active
           source:
-            type: string_list
+            type: string_list_as_string_list
             description: Source of the status change
             values:
               operator_panel: Operator panel
@@ -309,19 +309,19 @@ objects:
           Please note that all values in this status uses comma-separated lists - one value for each intersection, e.g. "0" and "True" (one intersection) or "1,2" and "True,False" (two intersections).
         arguments:
           intersection:
-            type: integer_list
+            type: integer_as_string_list
             description: |-
               Comma separated list of intersections which the status relates to, e.g. “1,2”.
               Use “0” for all intersections of the TLC.
             min: 0
             max: 255
           status:
-            type: boolean_list
+            type: boolean_as_string_list
             description: |-
               False: Fixed time control inactive
               True: Fixed time control active
           source:
-            type: string_list
+            type: string_list_as_string_list
             description: Source of the status change
             values:
               operator_panel: Operator panel
@@ -338,19 +338,19 @@ objects:
           Please note that all values in this status uses comma-separated lists - one value for each intersection, e.g. "0" and "True" (one intersection) or "1,2" and "True,False" (two intersections).
         arguments:
           intersection:
-            type: integer_list
+            type: integer_as_string_list
             description: |-
               Comma separated list of intersections which the status relates to, e.g. “1,2”.
               Use “0” for all intersections of the TLC.
             min: 0
             max: 255
           status:
-            type: boolean_list
+            type: boolean_as_string_list
             description: |-
               False: Isolated control disabled
               True: Isolated control enabled (Vehicle actuated control or Fixed time control)
           source:
-            type: string_list
+            type: string_list_as_string_list
             description: Source of the status change
             values:
               operator_panel: Operator panel
@@ -368,19 +368,19 @@ objects:
           Please note that all values in this status uses comma-separated lists - one value for each intersection, e.g. "1,2" and "True,False"
         arguments:
           intersection:
-            type: integer_list
+            type: integer_as_string_list
             description: |-
               Comma separated list of intersections which the status relates to, e.g. “1,2”.
               Use “0” for all intersections of the TLC.
             min: 0
             max: 255
           status:
-            type: boolean_list
+            type: boolean_as_string_list
             description: |-
               False: Yellow flash disabled
               True: Yellow flash enabled
           source:
-            type: string_list
+            type: string_list_as_string_list
             description: Source of the status change
             values:
               operator_panel: Operator panel
@@ -397,19 +397,19 @@ objects:
           Please note that all values in this status uses comma-separated lists - one value for each intersection, e.g. "1,2" and "True,False"
         arguments:
           intersection:
-            type: integer_list
+            type: integer_as_string_list
             description: |-
               Comma separated list of intersections which the status relates to, e.g. “1,2”.
               Use “0” for all intersections of the TLC.
             min: 0
             max: 255
           status:
-            type: boolean_list
+            type: boolean_as_string_list
             description: |-
               False: All red disabled
               True: All red enabled
           source:
-            type: string_list
+            type: string_list_as_string_list
             description: Source of the status change
             values:
               operator_panel: Operator panel
@@ -426,14 +426,14 @@ objects:
           Please note that all values in this status uses comma-separated lists - one value for each intersection, e.g. "1,2" and "0,1"
         arguments:
           intersection:
-            type: integer_list
+            type: integer_as_string_list
             description: |-
               Comma separated list of intersections which the status relates to, e.g. “1,2”.
               Use “0” for all intersections of the TLC.
             min: 0
             max: 255
           status:
-            type: integer_list
+            type: integer_as_string_list
             values:
               0: disabled
               1: dark mode
@@ -446,12 +446,12 @@ objects:
           The time plan (signal program) may change signal timings, cycle time, control strategy and much more. Typical usage is is scenario based control where change of program is used to change priority etc.
         arguments:
           status:
-            type: integer
+            type: integer_as_string
             description: Current time plan
             min: 1
             max: 255
           source:
-            type: string
+            type: string_list_as_string
             description: Source of the status change
             values:
               operator_panel: Operator panel
@@ -468,12 +468,12 @@ objects:
           Traffic situation is a concept used to divide multiple TLC's into areas and sub-areas. The traffic situation gives the possibility to change the TLC sub-area dynamically depending on the time of day and the traffic flow. Depending on the traffic situation each TLC selects the time plan dynamically.
         arguments:
           status:
-            type: integer
+            type: integer_as_string
             description: Current traffic situation
             min: 1
             max: 255
           source:
-            type: string
+            type: string_list_as_string
             description: Source of the status change
             values:
               operator_panel: Operator panel
@@ -488,7 +488,7 @@ objects:
           Can be used by the management system to check the number of detector logics configured in the controller.
         arguments:
           number:
-            type: integer
+            type: integer_as_string
             description: Number of detector logics
             min: 1
             max: 65025
@@ -498,7 +498,7 @@ objects:
           Can be used for the management system to check the number of signal groups configured in the controller.
         arguments:
           number:
-            type: integer
+            type: integer_as_string
             description: Number of signal groups
             min: 1
             max: 65025
@@ -508,7 +508,7 @@ objects:
           Can be used for the management system to check the number of traffic situations configured in the controller.
         arguments:
           number:
-            type: integer
+            type: integer_as_string
             description: Number of traffic situations
             min: 1
             max: 65025
@@ -519,14 +519,14 @@ objects:
           Please note that all values in this status uses comma-separated lists - one value for each intersection, e.g. "1,2" and "startup,control"
         arguments:
           intersection:
-            type: integer_list
+            type: integer_as_string_list
             description: |-
               Comma separated list of intersections which the status relates to, e.g. “1,2”.
               Use “0” for all intersections of the TLC.
             min: 0
             max: 255
           controlmode:
-            type: string_list
+            type: string_list_as_string_list
             values:
               startup: The controller starts up, performs a power on self test and performs each :term:`start-up interval`
               control: Normal 3-light control
@@ -556,7 +556,7 @@ objects:
           Can be used for the management system to check the number of time plans configured in the controller.
         arguments:
           status:
-            type: string
+            type: integer_list_as_string
             description: Comma separated list of configured time plans. E.g. "1,2,3,5"
       S0023:
         description: |-
@@ -585,7 +585,7 @@ objects:
           Can be used by the management system to check to fine tune the coordination for optimal traffic flow.
         arguments:
           status:
-            type: string
+            type: string_list_as_string
             description: |-
               Offset table
               Each offset time is written as p-t where:
@@ -604,7 +604,7 @@ objects:
           The week time table determine which predefined signal timings (time plan) to use during the week for optimal traffic flow.
         arguments:
           status:
-            type: string
+            type: string_list_as_string
             description: |-
               Week time table. Defines time table to use for each week day
               Each day is written as d-t where:
@@ -630,7 +630,7 @@ objects:
           The signal timings (time plan) to use during time of day for optimal traffic flow.
         arguments:
           status:
-            type: string
+            type: string_list_as_string
             description: |-
               Time Table. Defines time tables.
               Each time definition is written as t-o-h-m where:
@@ -658,7 +658,7 @@ objects:
           Changing the cycle time can be used as part of scenario based control.
         arguments:
           status:
-            type: string
+            type: string_list_as_string
             description: |-
               Cycle time table
               Each cycle time is written as pp-tt where:
@@ -706,7 +706,7 @@ objects:
           Can be used to make sure that the detectors detect traffic as intended.
         arguments:
           status:
-            type: string
+            type: string_list_as_string
             description: |-
               Loop detector trigger level sensitivity is written as dd-ss where:
               dd=loop detector number
@@ -719,21 +719,21 @@ objects:
           Please note that all values in this status uses comma-separated lists - one value for each intersection, e.g. “1,2” and “centralized,off”
         arguments:
           intersection:
-            type: integer_list
+            type: integer_as_string_list
             description: |-
               Comma separated list of intersections which the status relates to, e.g. “1,2”.
               Use “0” for all intersections of the TLC.
             min: 0
             max: 255
           status:
-            type: string_list
+            type: string_list_as_string_list
             values:
               local: Local coordination
               centralized: Coordination with synchronized clock
               'off': Coordination not active
           source:
             description: Source of the status change
-            type: string_list
+            type: string_list_as_string_list
             values:
               operator_panel: Operator panel
               calendar_clock: Calendar/clock
@@ -788,7 +788,7 @@ objects:
                   cooldown: A similar priority request means the priority request cannot be activated now
                   stale: The priority has been active too long without cancellation, and was therefore removed
               e:
-                type: integer
+                type: integer_as_string
                 description: |-
                   Estimated green extension provided by the priority, in seconds
                   Only used when state is ‘completed’.
@@ -796,7 +796,7 @@ objects:
                 min: 0
                 max: 255
               d:
-                type: integer
+                type: integer_as_string
                 description: |-
                   Estimated red reduction provided by the priority, in seconds
                   Only used when state is ‘completed’.
@@ -811,7 +811,7 @@ objects:
           Used in conjunction with dynamic bands, M0014
         arguments:
           status:
-            type: integer
+            type: integer_as_string
             description: Timeout, in minutes
             min: 0
             max: 65535
@@ -829,7 +829,7 @@ objects:
             type: array
             items:
               id:
-                type: integer
+                type: integer_as_string
                 description: ID of active emergency route
                 min: 1
                 max: 255
@@ -839,7 +839,7 @@ objects:
           Provides information if maintenance personnel is currently working on site.
         arguments:
           user:
-            type: integer
+            type: integer_as_string
             values:
               0: Nobody logged in
               1: Operator logged in at level 1 (read only)
@@ -850,7 +850,7 @@ objects:
           Provides information if maintenance personnel is currently working with the controller.
         arguments:
           user:
-            type: integer
+            type: integer_as_string
             values:
               0: Nobody logged in
               1: Operator logged in at level 1 (read only)
@@ -870,32 +870,32 @@ objects:
           Provides diagnostic information about the current date and time set in the controller.
         arguments:
           year:
-            type: integer
+            type: integer_as_string
             description: Year
             min: 0
             max: 9999
           month:
-            type: integer
+            type: integer_as_string
             description: Month
             min: 1
             max: 12
           day:
-            type: integer
+            type: integer_as_string
             description: Day of month
             min: 1
             max: 31
           hour:
-            type: integer
+            type: integer_as_string
             description: Hour
             min: 0
             max: 23
           minute:
-            type: integer
+            type: integer_as_string
             description: Minute
             min: 0
             max: 59
           second:
-            type: integer
+            type: integer_as_string
             description: Second
             min: 0
             max: 59
@@ -961,7 +961,7 @@ objects:
             type: timestamp
             description: Time stamp of the config
           version:
-            type: string
+            type: string_list_as_string
             description: |-
               Version information of the configuration. Contains basic information such as controller id, changes to config and other information.
               The format is not specified in detail.
@@ -974,7 +974,7 @@ objects:
             type: timestamp
             description: Time stamp for start of measuring
           vehicles:
-            type: integer_list
+            type: integer_as_string_list
             description: |-
               Number of vehicles.
               - Value expressed as an integer with a range of 0-65535.
@@ -991,7 +991,7 @@ objects:
             type: timestamp
             description: Time stamp for start of measuring
           speed:
-            type: integer_list
+            type: integer_as_string_list
             description: |-
               Average speed in km/h (integer).
               - Value expressed as an integer with a range of 0-65535.
@@ -1008,7 +1008,7 @@ objects:
             type: timestamp
             description: Time stamp for start of measuring
           occupancy:
-            type: integer_list
+            type: integer_as_string_list
             description: |-
               Occupancy in percent (%) (0-100)
               - Value expressed as an integer with a range of 0-100.
@@ -1025,7 +1025,7 @@ objects:
             type: timestamp
             description: Time stamp for start of measuring
           P:
-            type: integer_list
+            type: integer_as_string_list
             description: |-
               Number of cars.
               - Value expressed as an integer with a range of 0-65535.
@@ -1034,7 +1034,7 @@ objects:
             min: -1
             max: 65535
           PS:
-            type: integer_list
+            type: integer_as_string_list
             description: |-
               Number of cars with trailers.
               - Value expressed as an integer with a range of 0-65535.
@@ -1043,7 +1043,7 @@ objects:
             min: -1
             max: 65535
           L:
-            type: integer_list
+            type: integer_as_string_list
             description: |-
               Number of trucks.
               - Value expressed as an integer with a range of 0-65535.
@@ -1052,7 +1052,7 @@ objects:
             min: -1
             max: 65535
           LS:
-            type: integer_list
+            type: integer_as_string_list
             description: |-
               Number of trucks with trailers.
               - Value expressed as an integer with a range of 0-65535.
@@ -1061,7 +1061,7 @@ objects:
             min: -1
             max: 65535
           B:
-            type: integer_list
+            type: integer_as_string_list
             description: |-
               Number of buses.
               - Value expressed as an integer with a range of 0-65535.
@@ -1070,7 +1070,7 @@ objects:
             min: -1
             max: 65535
           SP:
-            type: integer_list
+            type: integer_as_string_list
             description: |-
               Number of trams.
               - Value expressed as an integer with a range of 0-65535.
@@ -1079,7 +1079,7 @@ objects:
             min: -1
             max: 65535
           MC:
-            type: integer_list
+            type: integer_as_string_list
             description: |-
               Number of motor cycles.
               - Value expressed as an integer with a range of 0-65535.
@@ -1088,7 +1088,7 @@ objects:
             min: -1
             max: 65535
           C:
-            type: integer_list
+            type: integer_as_string_list
             description: |-
               Number of bicycles.
               - Value expressed as an integer with a range of 0-65535.
@@ -1097,7 +1097,7 @@ objects:
             min: -1
             max: 65535
           F:
-            type: integer_list
+            type: integer_as_string_list
             description: |-
               Number of pedestrians.
               - Value expressed as an integer with a range of 0-65535.
@@ -1123,14 +1123,14 @@ objects:
             type: string
             description: Security code 2
           timeout:
-            type: integer
+            type: integer_as_string
             description: |-
               Time in minutes until controller automatically reverts to previous functional position.
               0=no automatic return
             min: 0
             max: 1440
           intersection:
-            type: integer
+            type: integer_as_string
             description: |-
               Intersection number.
               Command only applies to specified intersection. Other intersections remains in their respective operating mode(s).
@@ -1147,7 +1147,7 @@ objects:
           Requires security code 2
         arguments:
           status:
-            type: boolean
+            type: boolean_as_string
             description: |-
               False: Controller uses time plan according to programming
               True: Controller uses time plan according to command
@@ -1155,7 +1155,7 @@ objects:
             type: string
             description: Security code 2
           timeplan:
-            type: integer
+            type: integer_as_string
             description: designation of time plan
             min: 1
             max: 255
@@ -1168,7 +1168,7 @@ objects:
           Requires security code 2
         arguments:
           status:
-            type: boolean
+            type: boolean_as_string
             description: |-
               False: Controller uses traffic situation according to own programming
               True: Controller uses traffic situation according to command
@@ -1176,7 +1176,7 @@ objects:
             type: string
             description: Security code 2
           traficsituation:
-            type: integer
+            type: integer_as_string
             description: designation of traficsituation
             min: 1
             max: 255
@@ -1188,7 +1188,7 @@ objects:
           Requires security code 2
         arguments:
           status:
-            type: boolean
+            type: boolean_as_string
             deprecated: true
             description: 'True: Restart controller'
           securityCode:
@@ -1204,7 +1204,7 @@ objects:
           Requires security code 2.
         arguments:
           status:
-            type: boolean
+            type: boolean_as_string
             description: |-
               False: Deactivate emergency route
               True: Activate emergency route
@@ -1212,7 +1212,7 @@ objects:
             type: string
             description: Security code 2
           emergencyroute:
-            type: integer
+            type: integer_as_string
             description: Number of emergency route
             min: 1
             max: 255
@@ -1227,7 +1227,7 @@ objects:
           Requires security code 2.
         arguments:
           status:
-            type: boolean
+            type: boolean_as_string
             description: |-
               False: Deactivate input
               True: Activate input
@@ -1235,7 +1235,7 @@ objects:
             type: string
             description: Security code 2
           input:
-            type: integer
+            type: integer_as_string
             description: Number of Input
             min: 1
             max: 255
@@ -1248,7 +1248,7 @@ objects:
           Requires security code 2.
         arguments:
           status:
-            type: boolean
+            type: boolean_as_string
             description: |-
               False: Deactivate fixed time control
               True: Activate fixed time control
@@ -1269,7 +1269,7 @@ objects:
         reserved: true
         arguments:
           status:
-            type: string
+            type: string_list_as_string
             description: |-
               Orders signal groups to green or red. Sets a block of 16 signal groups at a time. Can be repeated to set several blocks of 16 signal groups. Values are separated with comma. Blocks are separated with semicolon. Since semicolon breaks the SXL csv-format, colon is used in example below.
               
@@ -1333,7 +1333,7 @@ objects:
           - “2” is 10 in binary, which is bit 1
         arguments:
           status:
-            type: string
+            type: string_list_as_string
             description: |-
               Sets/Unsets a block of 16 inputs at a time. Can be repeated to set several blocks of 16 inputs. Values are separated with comma. Blocks are separated with semicolon.
               Format: [Offset];[Bits to set];[Bits to unset];…
@@ -1349,12 +1349,12 @@ objects:
           Requires security code 2
         arguments:
           plan:
-            type: integer
+            type: integer_as_string
             description: Plan to be changed
             min: 0
             max: 255
           status:
-            type: string
+            type: string_list_as_string
             description: |-
               Dynamic bands.
               Each dynamic band are written as dd-ee where:
@@ -1377,12 +1377,12 @@ objects:
           Requires security code 2.
         arguments:
           status:
-            type: integer
+            type: integer_as_string
             description: Set offset time in seconds
             min: 0
             max: 255
           plan:
-            type: integer
+            type: integer_as_string
             description: Time plan nr
             min: 0
             max: 255
@@ -1398,7 +1398,7 @@ objects:
           Requires security code 2.
         arguments:
           status:
-            type: string
+            type: string_list_as_string
             description: |-
               Week time table. Defines time table to use for each week day
               Each segment is written as d-t where:
@@ -1430,7 +1430,7 @@ objects:
           Requires security code 2.
         arguments:
           status:
-            type: string
+            type: string_list_as_string
             description: |-
               Time Table. Defines time tables.
               Each time definition is written as t-o-h-m where:
@@ -1463,12 +1463,12 @@ objects:
           Requires security code 2.
         arguments:
           status:
-            type: integer
+            type: integer_as_string
             description: Set cycle time in seconds
             min: 1
             max: 255
           plan:
-            type: integer
+            type: integer_as_string
             description: Time plan nr
             min: 0
             max: 255
@@ -1484,7 +1484,7 @@ objects:
           Requires security code 2.
         arguments:
           status:
-            type: boolean
+            type: boolean_as_string
             description: |-
               False: Release input
               True: Force input
@@ -1492,12 +1492,12 @@ objects:
             type: string
             description: Security code 2
           input:
-            type: integer
+            type: integer_as_string
             description: Number of Input
             min: 1
             max: 255
           inputValue:
-            type: boolean
+            type: boolean_as_string
             description: |-
               False: input forced to False
               True: input forced to True
@@ -1511,7 +1511,7 @@ objects:
           Requires security code 2.
         arguments:
           status:
-            type: boolean
+            type: boolean_as_string
             description: |-
               True: Force output
               False: Release output
@@ -1519,12 +1519,12 @@ objects:
             type: string
             description: Security code 2
           output:
-            type: integer
+            type: integer_as_string
             description: Number of Output
             min: 1
             max: 255
           outputValue:
-            type: boolean
+            type: boolean_as_string
             description: |-
               False: output forced off
               True: output forced on
@@ -1537,7 +1537,7 @@ objects:
           Requires security code 2
         arguments:
           status:
-            type: string
+            type: string_list_as_string
             description: |-
               Loop detector trigger level sensitivity is written as dd-ss where:
               dd=loop detector number
@@ -1607,37 +1607,37 @@ objects:
             optional: true
             description: ID of a signal group component.
           inputId:
-            type: integer
+            type: integer_as_string
             optional: true
             description: ID of an input, using the same numbering scheme as M0006
             min: 0
             max: 255
           connectionId:
-            type: integer
+            type: integer_as_string
             optional: true
             description: ID of a connection, connecting an ingoing and an outgoing lane
             min: 0
             max: 255
           approachId:
-            type: integer
+            type: integer_as_string
             optional: true
             description: ID of an intersection approach
             min: 0
             max: 16
           laneInId:
-            type: integer
+            type: integer_as_string
             optional: true
             description: ID of an ingoing lane
             min: 0
             max: 255
           laneOutId:
-            type: integer
+            type: integer_as_string
             optional: true
             description: ID of an outgoing lane
             min: 0
             max: 255
           priorityId:
-            type: integer
+            type: integer_as_string
             optional: true
             description: ID of a priority
             min: 0
@@ -1649,13 +1649,13 @@ objects:
               update: Update to existing priority request
               cancel: Cancel an existing priority
           level:
-            type: integer
+            type: integer_as_string
             description: |-
               0: Lowest, 14: Highest
             min: 0
             max: 14
           eta:
-            type: integer
+            type: integer_as_string
             optional: true
             description: Estimated time of arrival to the intersection, in seconds
             min: 0
@@ -1687,7 +1687,7 @@ objects:
           Requires security code 2.
         arguments:
           status:
-            type: integer
+            type: integer_as_string
             min: 0
             max: 65535
             description: Timeout, in minutes
@@ -1724,32 +1724,32 @@ objects:
             type: string
             description: Security code 1
           year:
-            type: integer
+            type: integer_as_string
             description: Year
             min: 0
             max: 9999
           month:
-            type: integer
+            type: integer_as_string
             description: Month
             min: 1
             max: 12
           day:
-            type: integer
+            type: integer_as_string
             description: Day of month
             min: 1
             max: 31
           hour:
-            type: integer
+            type: integer_as_string
             description: Hour
             min: 0
             max: 23
           minute:
-            type: integer
+            type: integer_as_string
             description: Minute
             min: 0
             max: 59
           second:
-            type: integer
+            type: integer_as_string
             description: Second
             min: 0
             max: 59
@@ -1767,7 +1767,7 @@ objects:
         category: D
         arguments:
           timeplan:
-            type: integer
+            type: integer_as_string
             description: Current time plan
             min: 1
             max: 255
@@ -1826,7 +1826,7 @@ objects:
             description: |-
               Time stamp for the most likely time for the signal group to go to green. If the signal group is green, it is the most likely time for the next green.
           ToGConfidence:
-            type: integer
+            type: integer_as_string
             description: Confidence of the likelyToGEstimate. 0-100%
             min: 0
             max: 100
@@ -1843,7 +1843,7 @@ objects:
             description: |-
               Time stamp for the most likely time for the signal group to go to red. If the signal group is red, it is the most likely time for the next red.
           ToRConfidence:
-            type: integer
+            type: integer_as_string
             description: Confidence of the likelyToREstimate. 0-100%
             min: 0
             max: 100
@@ -1857,7 +1857,7 @@ objects:
         reserved: true
         arguments:
           status:
-            type: boolean
+            type: boolean_as_string
             description: |-
               False: No command (default)
               True: Order a signal group to green
@@ -1874,7 +1874,7 @@ objects:
         reserved: true
         arguments:
           status:
-            type: boolean
+            type: boolean_as_string
             description: |-
               False: No command (default)
               True: Order a signal group to red
@@ -1906,7 +1906,7 @@ objects:
             description: Detector forced on/off while detector error
             values: ['on','off'] # on/off must be quoted, otherwise they are converted to true/false
           manual:
-            type: boolean
+            type: boolean_as_string
             description: Manually controlled detector logic (True/False)
       A0302:
         description: |-
@@ -1930,7 +1930,7 @@ objects:
             description: Detector forced on/off while detector error
             values: ['on','off'] # on/off must be quoted, otherwise they are converted to true/false
           manual:
-            type: boolean
+            type: boolean_as_string
             description: Manually controlled detector logic (True/False)
           logicerror:
             type: string
@@ -1960,7 +1960,7 @@ objects:
             description: Detector forced on/off while detector error
             values: ['on','off'] # on/off must be quoted, otherwise they are converted to true/false
           manual:
-            type: boolean
+            type: boolean_as_string
             description: Manually controlled detector logic (True/False)
       A0304:
         description: |-
@@ -1984,7 +1984,7 @@ objects:
             description: Detector forced on/off while detector error
             values: ['on','off'] # on/off must be quoted, otherwise they are converted to true/false
           manual:
-            type: boolean
+            type: boolean_as_string
             description: Manually controlled detector logic (True/False)
           logicerror:
             type: string
@@ -2003,7 +2003,7 @@ objects:
             type: timestamp
             description: Time stamp for start of measuring
           vehicles:
-            type: integer
+            type: integer_as_string
             description: Number of vehicles on a given detector logic (since last
               update)
             min: 0
@@ -2017,7 +2017,7 @@ objects:
             type: timestamp
             description: Time stamp for start of measuring
           speed:
-            type: integer
+            type: integer_as_string
             description: Average speed in km/h
             min: 0
             max: 65535
@@ -2030,7 +2030,7 @@ objects:
             type: timestamp
             description: Time stamp for start of measuring
           occupancy:
-            type: integer
+            type: integer_as_string
             description: Occupancy in percent (0-100%)
             min: 0
             max: 100
@@ -2043,47 +2043,47 @@ objects:
             type: timestamp
             description: Time stamp for start of measuring
           P:
-            type: integer
+            type: integer_as_string
             description: Number of cars
             min: 0
             max: 65535
           PS:
-            type: integer
+            type: integer_as_string
             description: Number of cars with trailers
             min: 0
             max: 65535
           L:
-            type: integer
+            type: integer_as_string
             description: Number of trucks
             min: 0
             max: 65535
           LS:
-            type: integer
+            type: integer_as_string
             description: Number of trucks with trailers
             min: 0
             max: 65535
           B:
-            type: integer
+            type: integer_as_string
             description: Number of buses
             min: 0
             max: 65535
           SP:
-            type: integer
+            type: integer_as_string
             description: Number of trams
             min: 0
             max: 65535
           MC:
-            type: integer
+            type: integer_as_string
             description: Number of motor cycles
             min: 0
             max: 65535
           C:
-            type: integer
+            type: integer_as_string
             description: Number of bicycles
             min: 0
             max: 65535
           F:
-            type: integer
+            type: integer_as_string
             description: Number of pedestrians
             min: 0
             max: 65535
@@ -2096,7 +2096,7 @@ objects:
           Requires security code 2
         arguments:
           status:
-            type: boolean
+            type: boolean_as_string
             description: |-
               False: Deactivate manual control of detector logic
               True: Activate manual control of detector logic
@@ -2104,7 +2104,7 @@ objects:
             type: string
             description: Security code 2
           mode:
-            type: boolean
+            type: boolean_as_string
             description: |-
               False: Deactivate detector logic
               True: Activate detector logic


### PR DESCRIPTION
Since we're allowing all json types in the upcoming RSMP 3.3.0 and renaming existing ones, we need to update the SXL to reflect that (See https://github.com/rsmp-nordic/rsmp_sxl_traffic_lights/issues/219).